### PR TITLE
pin-1849: Bubble up interop services errors

### DIFF
--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/AgreementsApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/AgreementsApiServiceImpl.scala
@@ -1,31 +1,30 @@
 package it.pagopa.interop.backendforfrontend.api.impl
 
 import akka.http.scaladsl.marshalling.ToEntityMarshaller
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.Directives.{complete, onComplete}
-import akka.http.scaladsl.server.{Route, StandardRoute}
+import akka.http.scaladsl.server.Directives.onComplete
+import akka.http.scaladsl.server.Route
 import cats.implicits._
-import com.typesafe.scalalogging.Logger
+import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
 import it.pagopa.interop.agreementprocess.client.{model => AgreementProcess}
 import it.pagopa.interop.attributeregistrymanagement.client.{model => AttributeRegistry}
 import it.pagopa.interop.backendforfrontend.api.AgreementsApiService
 import it.pagopa.interop.backendforfrontend.error.BFFErrors.AgreementDescriptorNotFound
+import it.pagopa.interop.backendforfrontend.error.Handlers.handleError
 import it.pagopa.interop.backendforfrontend.model._
+import it.pagopa.interop.backendforfrontend.service._
 import it.pagopa.interop.backendforfrontend.service.types.AgreementProcessServiceTypes.{AgreementPayloadConverter, _}
 import it.pagopa.interop.backendforfrontend.service.types.AttributeRegistryServiceTypes.{MgmtAttributesResponse, _}
 import it.pagopa.interop.backendforfrontend.service.types.CatalogManagementServiceTypes._
 import it.pagopa.interop.backendforfrontend.service.types.TenantManagementServiceTypes._
-import it.pagopa.interop.backendforfrontend.service._
 import it.pagopa.interop.catalogmanagement.client.{model => CatalogManagement}
 import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
 import it.pagopa.interop.commons.utils.OpenapiUtils.parseArrayParameters
 import it.pagopa.interop.commons.utils.TypeConversions._
-import it.pagopa.interop.commons.utils.errors.GenericComponentErrors.{GenericError, ResourceNotFoundError}
 import it.pagopa.interop.tenantmanagement.client.{model => TenantManagement}
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.util.Success
 
 final case class AgreementsApiServiceImpl(
   agreementProcessService: AgreementProcessService,
@@ -36,7 +35,8 @@ final case class AgreementsApiServiceImpl(
 )(implicit ec: ExecutionContext)
     extends AgreementsApiService {
 
-  private val logger = Logger.takingImplicit[ContextFieldsToLog](this.getClass)
+  private implicit val logger: LoggerTakingImplicit[ContextFieldsToLog] =
+    Logger.takingImplicit[ContextFieldsToLog](this.getClass)
 
   override def createAgreement(payload: AgreementPayload)(implicit
     contexts: Seq[(String, String)],
@@ -48,13 +48,12 @@ final case class AgreementsApiServiceImpl(
     } yield CreatedResource(result.id)
 
     onComplete(result) {
-      case Success(resource) =>
+      handleError(
+        s"Error creating agreement for EService ${payload.eserviceId} and Descriptor ${payload.descriptorId}"
+      ) orElse { case Success(resource) =>
         createAgreement200(resource)
-      case Failure(e)        =>
-        val message =
-          s"Error while creating agreement for EService ${payload.eserviceId} and Descriptor ${payload.descriptorId}"
-        logger.error(message, e)
-        internalServerError(message)
+
+      }
     }
   }
 
@@ -70,14 +69,9 @@ final case class AgreementsApiServiceImpl(
     } yield apiAgreement
 
     onComplete(agreement) {
-      case Success(agreement)                 => getAgreementById200(agreement)
-      case Failure(ex: ResourceNotFoundError) =>
-        logger.error(s"Error while retrieving agreement  $agreementId", ex)
-        getAgreementById404(problemOf(StatusCodes.NotFound, ex))
-      case Failure(e)                         =>
-        val message = s"Error while retrieving agreement $agreementId"
-        logger.error(message, e)
-        internalServerError(message)
+      handleError(s"Error retrieving agreement $agreementId") orElse { case Success(agreement) =>
+        getAgreementById200(agreement)
+      }
     }
   }
 
@@ -107,11 +101,7 @@ final case class AgreementsApiServiceImpl(
     } yield apiAgreements
 
     onComplete(agreements) {
-      case Success(agreements) => getAgreements200(agreements)
-      case Failure(e)          =>
-        val message = s"Error while retrieving agreements"
-        logger.error(message, e)
-        internalServerError(message)
+      handleError(s"Error retrieving agreements") orElse { case Success(agreements) => getAgreements200(agreements) }
     }
   }
 
@@ -127,14 +117,9 @@ final case class AgreementsApiServiceImpl(
     } yield apiAgreement
 
     onComplete(agreement) {
-      case Success(agreement)                 => activateAgreement200(agreement)
-      case Failure(ex: ResourceNotFoundError) =>
-        logger.error(s"Error while activating agreement  $agreementId", ex)
-        activateAgreement404(problemOf(StatusCodes.NotFound, ex))
-      case Failure(e)                         =>
-        val message = s"Error while activating agreement $agreementId"
-        logger.error(message, e)
-        internalServerError(message)
+      handleError(s"Error activating agreement $agreementId") orElse { case Success(agreement) =>
+        activateAgreement200(agreement)
+      }
     }
   }
 
@@ -150,14 +135,9 @@ final case class AgreementsApiServiceImpl(
     } yield apiAgreement
 
     onComplete(agreement) {
-      case Success(agreement)                 => submitAgreement200(agreement)
-      case Failure(ex: ResourceNotFoundError) =>
-        logger.error(s"Error while submitting agreement $agreementId", ex)
-        submitAgreement404(problemOf(StatusCodes.NotFound, ex))
-      case Failure(e)                         =>
-        val message = s"Error while submitting agreement $agreementId"
-        logger.error(message, e)
-        internalServerError(message)
+      handleError(s"Error submitting agreement $agreementId") orElse { case Success(agreement) =>
+        submitAgreement200(agreement)
+      }
     }
   }
 
@@ -173,14 +153,9 @@ final case class AgreementsApiServiceImpl(
     } yield apiAgreement
 
     onComplete(agreement) {
-      case Success(agreement)                 => suspendAgreement200(agreement)
-      case Failure(ex: ResourceNotFoundError) =>
-        logger.error(s"Error while suspending agreement $agreementId", ex)
-        suspendAgreement404(problemOf(StatusCodes.NotFound, ex))
-      case Failure(e)                         =>
-        val message = s"Error while suspending agreement $agreementId"
-        logger.error(message, e)
-        internalServerError(message)
+      handleError(s"Error suspending agreement $agreementId") orElse { case Success(agreement) =>
+        suspendAgreement200(agreement)
+      }
     }
   }
 
@@ -196,14 +171,9 @@ final case class AgreementsApiServiceImpl(
     } yield apiAgreement
 
     onComplete(agreement) {
-      case Success(agreement)                 => upgradeAgreement200(agreement)
-      case Failure(ex: ResourceNotFoundError) =>
-        logger.error(s"Error while upgrading agreement  $agreementId", ex)
-        upgradeAgreement404(problemOf(StatusCodes.NotFound, ex))
-      case Failure(e)                         =>
-        val message = s"Error while upgrading agreement $agreementId"
-        logger.error(message, e)
-        internalServerError(message)
+      handleError(s"Error upgrading agreement $agreementId") orElse { case Success(agreement) =>
+        upgradeAgreement200(agreement)
+      }
     }
   }
 
@@ -296,13 +266,6 @@ final case class AgreementsApiServiceImpl(
     }
 
     TenantAttribute(declared = declared, certified = certified, verified = verified)
-  }
-
-  private def internalServerError(
-    errorMessage: String
-  )(implicit toEntityMarshallerProblem: ToEntityMarshaller[Problem]): StandardRoute = {
-    val statusCode = StatusCodes.InternalServerError
-    complete(statusCode.intValue, problemOf(statusCode, GenericError(errorMessage)))
   }
 
 }

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/AttributesApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/AttributesApiServiceImpl.scala
@@ -1,31 +1,26 @@
 package it.pagopa.interop.backendforfrontend.api.impl
 
 import akka.http.scaladsl.marshalling.ToEntityMarshaller
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.Directives.{complete, onComplete}
+import akka.http.scaladsl.server.Directives.onComplete
 import akka.http.scaladsl.server.Route
-import com.typesafe.scalalogging.Logger
+import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
 import it.pagopa.interop.backendforfrontend.api.AttributesApiService
-import it.pagopa.interop.backendforfrontend.model.{Attribute, AttributesResponse, Problem}
+import it.pagopa.interop.backendforfrontend.error.Handlers.handleError
+import it.pagopa.interop.backendforfrontend.model.{Attribute, AttributeSeed, AttributesResponse, Problem}
 import it.pagopa.interop.backendforfrontend.service.AttributeRegistryManagementService
 import it.pagopa.interop.backendforfrontend.service.types.AttributeRegistryServiceTypes._
 import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
 import it.pagopa.interop.commons.utils.TypeConversions._
-import it.pagopa.interop.commons.utils.errors.GenericComponentErrors.{
-  GenericError,
-  ResourceNotFoundError,
-  ResourceConflictError
-}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
-import it.pagopa.interop.backendforfrontend.model.AttributeSeed
+import scala.util.Success
 
 final case class AttributesApiServiceImpl(attributeRegistryManagementApiService: AttributeRegistryManagementService)(
   implicit ec: ExecutionContext
 ) extends AttributesApiService {
 
-  private val logger = Logger.takingImplicit[ContextFieldsToLog](this.getClass)
+  private implicit val logger: LoggerTakingImplicit[ContextFieldsToLog] =
+    Logger.takingImplicit[ContextFieldsToLog](this.getClass)
 
   override def getAttributes(search: Option[String])(implicit
     contexts: Seq[(String, String)],
@@ -36,24 +31,9 @@ final case class AttributesApiServiceImpl(attributeRegistryManagementApiService:
       attributeRegistryManagementApiService.getAttributes(search)(contexts).map(_.toResponse)
 
     onComplete(result) {
-      case Success(attributes)                =>
+      handleError(s"Error retrieving attributes for search string $search") orElse { case Success(attributes) =>
         getAttributes200(attributes)
-      case Failure(ex: ResourceNotFoundError) =>
-        logger.error(s"Error while getting attributes for search string $search - ${ex.getMessage}")
-        getAttributes404(
-          problemOf(StatusCodes.NotFound, ResourceNotFoundError(s"Attributes containing string $search"))
-        )
-      case Failure(ex)                        =>
-        logger.error(s"Error while getting attributes for search string $search - ${ex.getMessage}")
-        complete(
-          StatusCodes.InternalServerError,
-          problemOf(
-            StatusCodes.InternalServerError,
-            GenericError(
-              s"Something went wrong trying to search attributes containing string $search - ${ex.getMessage}"
-            )
-          )
-        )
+      }
     }
   }
 
@@ -69,20 +49,9 @@ final case class AttributesApiServiceImpl(attributeRegistryManagementApiService:
     } yield converted
 
     onComplete(result) {
-      case Success(attribute)                 =>
+      handleError(s"Error retrieving attribute with id $attributeId") orElse { case Success(attribute) =>
         getAttributeById200(attribute)
-      case Failure(ex: ResourceNotFoundError) =>
-        logger.error(s"Error while getting attribute with id $attributeId", ex)
-        getAttributes404(problemOf(StatusCodes.NotFound, ResourceNotFoundError(s"Attribute with id $attributeId")))
-      case Failure(ex)                        =>
-        logger.error(s"Error while getting attribute with id $attributeId", ex)
-        complete(
-          StatusCodes.InternalServerError,
-          problemOf(
-            StatusCodes.InternalServerError,
-            GenericError(s"Something went wrong trying to get attribute with id $attributeId - ${ex.getMessage}")
-          )
-        )
+      }
     }
   }
 
@@ -97,27 +66,9 @@ final case class AttributesApiServiceImpl(attributeRegistryManagementApiService:
     } yield converted
 
     onComplete(result) {
-      case Success(attribute)                 =>
-        getAttributeByOriginAndCode200(attribute)
-      case Failure(ex: ResourceNotFoundError) =>
-        logger.error(s"Error while getting attribute with origin = $origin and code = $code - ${ex.getMessage}")
-        getAttributes404(
-          problemOf(
-            StatusCodes.NotFound,
-            ResourceNotFoundError(s"Attribute with origin = $origin and code = $code not found")
-          )
-        )
-      case Failure(ex)                        =>
-        logger.error(s"Error while getting attribute with origin = $origin and code = $code - ${ex.getMessage}")
-        complete(
-          StatusCodes.InternalServerError,
-          problemOf(
-            StatusCodes.InternalServerError,
-            GenericError(
-              s"Something went wrong trying to get attribute with origin = $origin and code = $code - ${ex.getMessage}"
-            )
-          )
-        )
+      handleError(s"Error retrieving attribute with origin = $origin and code = $code") orElse {
+        case Success(attribute) => getAttributeByOriginAndCode200(attribute)
+      }
     }
   }
 
@@ -131,23 +82,9 @@ final case class AttributesApiServiceImpl(attributeRegistryManagementApiService:
     } yield result.toAttribute
 
     onComplete(result) {
-      case Success(attribute)                =>
+      handleError(s"Error creating attribute with seed $attributeSeed") orElse { case Success(attribute) =>
         createAttribute201(attribute)
-      case Failure(e: ResourceConflictError) =>
-        val errorMessage: String = s"Attribute with name ${e.resourceId} already existing"
-        logger.error(s"Error while creating attribute with seed $attributeSeed - $errorMessage")
-        createAttribute409(problemOf(StatusCodes.Conflict, ResourceConflictError(errorMessage)))
-      case Failure(e)                        =>
-        logger.error(s"Error while creating attribute with seed $attributeSeed", e)
-        complete(
-          StatusCodes.InternalServerError,
-          problemOf(
-            StatusCodes.InternalServerError,
-            GenericError(
-              s"Something went wrong trying to create an attribute with seed $attributeSeed - ${e.getMessage}"
-            )
-          )
-        )
+      }
     }
   }
 

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/AuthorizationApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/AuthorizationApiServiceImpl.scala
@@ -1,17 +1,16 @@
 package it.pagopa.interop.backendforfrontend.api.impl
 
 import akka.http.scaladsl.marshalling.ToEntityMarshaller
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.Directives.{complete, onComplete}
+import akka.http.scaladsl.server.Directives.onComplete
 import akka.http.scaladsl.server.Route
 import com.nimbusds.jwt.JWTClaimsSet
 import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
 import it.pagopa.interop.backendforfrontend.api.AuthorizationApiService
 import it.pagopa.interop.backendforfrontend.common.system.ApplicationConfiguration
-import it.pagopa.interop.backendforfrontend.error.BFFErrors.CreateSessionTokenRequestError
+import it.pagopa.interop.backendforfrontend.error.Handlers.handleError
 import it.pagopa.interop.backendforfrontend.model.{IdentityToken, SessionToken}
-import it.pagopa.interop.commons.jwt.{getUserRoles, organizationClaim}
 import it.pagopa.interop.commons.jwt.service.{JWTReader, SessionTokenGenerator}
+import it.pagopa.interop.commons.jwt.{getUserRoles, organizationClaim}
 import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
 import it.pagopa.interop.commons.signer.model.SignatureAlgorithm
 import it.pagopa.interop.commons.utils.TypeConversions.{OptionOps, TryOps}
@@ -20,7 +19,7 @@ import it.pagopa.interop.commons.utils.{ORGANIZATION, ORGANIZATION_ID_CLAIM, UID
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.jdk.CollectionConverters.MapHasAsScala
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 final case class AuthorizationApiServiceImpl(jwtReader: JWTReader, sessionTokenGenerator: SessionTokenGenerator)(
   implicit ec: ExecutionContext
@@ -30,7 +29,7 @@ final case class AuthorizationApiServiceImpl(jwtReader: JWTReader, sessionTokenG
   private val FAMILY_NAME: String = "family_name"
   private val EMAIL: String       = "email"
 
-  private val logger: LoggerTakingImplicit[ContextFieldsToLog] =
+  private implicit val logger: LoggerTakingImplicit[ContextFieldsToLog] =
     Logger.takingImplicit[ContextFieldsToLog](this.getClass)
 
   private val admittedSessionClaims: Set[String] = Set(UID, ORGANIZATION, NAME, FAMILY_NAME, EMAIL)
@@ -57,13 +56,9 @@ final case class AuthorizationApiServiceImpl(jwtReader: JWTReader, sessionTokenG
     } yield SessionToken(token)
 
     onComplete(result) {
-      case Success(token) => getSessionToken200(token)
-      case Failure(ex)    =>
-        logger.error(s"Error while creating a session token for this request - ${ex.getMessage}")
-        complete(
-          StatusCodes.InternalServerError,
-          problemOf(StatusCodes.InternalServerError, CreateSessionTokenRequestError)
-        )
+      handleError(s"Error creating a session token") orElse { case Success(token) =>
+        getSessionToken200(token)
+      }
     }
   }
 

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/TenantsApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/TenantsApiServiceImpl.scala
@@ -1,23 +1,22 @@
 package it.pagopa.interop.backendforfrontend.api.impl
 
 import akka.http.scaladsl.marshalling.ToEntityMarshaller
-import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.server.Directives.{complete, onComplete}
+import akka.http.scaladsl.server.Directives.onComplete
 import akka.http.scaladsl.server.Route
 import cats.implicits._
 import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
 import it.pagopa.interop.attributeregistrymanagement.client.model.Attribute
 import it.pagopa.interop.backendforfrontend.api.TenantsApiService
+import it.pagopa.interop.backendforfrontend.error.Handlers.handleError
 import it.pagopa.interop.backendforfrontend.model.{CertifiedAttributesResponse, Problem}
 import it.pagopa.interop.backendforfrontend.service.types.AttributeRegistryServiceTypes.AttributeConverter
 import it.pagopa.interop.backendforfrontend.service.{AttributeRegistryManagementService, TenantManagementService}
 import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
 import it.pagopa.interop.commons.utils.TypeConversions._
-import it.pagopa.interop.commons.utils.errors.GenericComponentErrors.{GenericError, ResourceNotFoundError}
 import it.pagopa.interop.tenantmanagement.client.model.CertifiedTenantAttribute
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.util.Success
 
 final case class TenantsApiServiceImpl(
   attributeRegistryService: AttributeRegistryManagementService,
@@ -25,10 +24,10 @@ final case class TenantsApiServiceImpl(
 )(implicit ec: ExecutionContext)
     extends TenantsApiService {
 
-  private val logger: LoggerTakingImplicit[ContextFieldsToLog] =
+  private implicit val logger: LoggerTakingImplicit[ContextFieldsToLog] =
     Logger.takingImplicit[ContextFieldsToLog](this.getClass)
 
-  override def getCertifiedAttributes(institutionId: String)(implicit
+  override def getCertifiedAttributes(tenantId: String)(implicit
     contexts: Seq[(String, String)],
     toEntityMarshallerProblem: ToEntityMarshaller[Problem],
     toEntityMarshallerCertifiedAttributesResponse: ToEntityMarshaller[CertifiedAttributesResponse]
@@ -46,26 +45,15 @@ final case class TenantsApiServiceImpl(
         )
 
     val result: Future[CertifiedAttributesResponse] = for {
-      institutionUUID <- institutionId.toFutureUUID
-      tenant          <- tenantManagementService.getTenant(institutionUUID)
-      attributes      <- Future.traverse(tenant.attributes.mapFilter(_.certified))(getAttributeSafe).map(_.flatten)
+      tenantUUID <- tenantId.toFutureUUID
+      tenant     <- tenantManagementService.getTenant(tenantUUID)
+      attributes <- Future.traverse(tenant.attributes.mapFilter(_.certified))(getAttributeSafe).map(_.flatten)
     } yield CertifiedAttributesResponse(attributes.map(_.toCertifiedAttribute))
 
     onComplete(result) {
-      case Success(attributes)               =>
+      handleError(s"Error retrieving certified attributes for tenant $tenantId") orElse { case Success(attributes) =>
         getCertifiedAttributes200(attributes)
-      case Failure(e: ResourceNotFoundError) =>
-        logger.error(s"Error while retrieving certified attributes for $institutionId", e)
-        getCertifiedAttributes404(problemOf(StatusCodes.NotFound, e))
-      case Failure(e)                        =>
-        logger.error(s"Error while retrieving certified attributes for $institutionId", e)
-        complete(
-          StatusCodes.InternalServerError,
-          problemOf(
-            StatusCodes.InternalServerError,
-            GenericError(s"Error while retrieving certified attributes for $institutionId")
-          )
-        )
+      }
     }
   }
 

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/error/BFFErrors.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/error/BFFErrors.scala
@@ -6,9 +6,6 @@ import java.util.UUID
 
 object BFFErrors {
 
-  final case object CreateSessionTokenRequestError
-      extends ComponentError("0001", s"Error while creating a session token for this request")
-
   final case class RelationshipNotFound(relationshipId: String)
       extends ComponentError("0002", s"Relationship $relationshipId not found")
 

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/error/Handlers.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/error/Handlers.scala
@@ -52,11 +52,11 @@ object Handlers {
     complete(problem.status, problem)
   }
 
-  private def responseToProblem(
-    problemBody: String
-  )(implicit toEntityMarshallerProblem: ToEntityMarshaller[Problem]): Problem =
+  private def responseToProblem(problemBody: String): Problem =
+    // Note: the body is actually a Problem of the below service, but the model is the same,
+    //   so we can convert directly to our model for convenience
     Try(problemBody.parseJson.convertTo[Problem])
-      .getOrElse(problemOf(StatusCodes.InternalServerError, GenericError("errorMessage"))) // TODO message
+      .getOrElse(problemOf(StatusCodes.InternalServerError, GenericError("Unexpected error")))
 
   private def internalServerError(
     errorMessage: String

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/error/Handlers.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/error/Handlers.scala
@@ -1,0 +1,67 @@
+package it.pagopa.interop.backendforfrontend.error
+
+import akka.http.scaladsl.marshalling.ToEntityMarshaller
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives.complete
+import akka.http.scaladsl.server.StandardRoute
+import com.typesafe.scalalogging.LoggerTakingImplicit
+import it.pagopa.interop.agreementprocess.client.invoker.{ApiError => AgreementProcessError}
+import it.pagopa.interop.attributeregistrymanagement.client.invoker.{ApiError => AttributeRegistryError}
+import it.pagopa.interop.backendforfrontend.api.impl.{problemFormat, problemOf}
+import it.pagopa.interop.backendforfrontend.model.Problem
+import it.pagopa.interop.catalogmanagement.client.invoker.{ApiError => CatalogManagementError}
+import it.pagopa.interop.commons.logging.ContextFieldsToLog
+import it.pagopa.interop.commons.utils.errors.GenericComponentErrors.GenericError
+import it.pagopa.interop.selfcare.partyprocess.client.invoker.{ApiError => PartyProcessError}
+import it.pagopa.interop.selfcare.userregistry.client.invoker.{ApiError => UserRegistryError}
+import it.pagopa.interop.tenantmanagement.client.invoker.{ApiError => TenantManagementError}
+import spray.json._
+
+import scala.util.{Failure, Try}
+
+object Handlers {
+
+  def handleError(logMessage: String)(implicit
+    contexts: Seq[(String, String)],
+    logger: LoggerTakingImplicit[ContextFieldsToLog],
+    toEntityMarshallerProblem: ToEntityMarshaller[Problem]
+  ): PartialFunction[Try[_], StandardRoute] = log(logMessage) andThen {
+    case Failure(err: AgreementProcessError[_])  => completeWithError(err.message)
+    case Failure(err: AttributeRegistryError[_]) => completeWithError(err.message)
+    case Failure(err: CatalogManagementError[_]) => completeWithError(err.message)
+    case Failure(err: TenantManagementError[_])  => completeWithError(err.message)
+    case Failure(err: PartyProcessError[_])      => completeWithError(err.message)
+    case Failure(err: UserRegistryError[_])      => completeWithError(err.message)
+    case Failure(_)                              => internalServerError(logMessage)
+  }
+
+  private def log(logMessage: String)(implicit
+    contexts: Seq[(String, String)],
+    logger: LoggerTakingImplicit[ContextFieldsToLog]
+  ): PartialFunction[Try[_], Try[_]] = {
+    case res @ Failure(ex) =>
+      logger.error(logMessage, ex)
+      res
+    case other             => other
+  }
+
+  private def completeWithError(
+    problemBody: String
+  )(implicit toEntityMarshallerProblem: ToEntityMarshaller[Problem]): StandardRoute = {
+    val problem = responseToProblem(problemBody)
+    complete(problem.status, problem)
+  }
+
+  private def responseToProblem(
+    problemBody: String
+  )(implicit toEntityMarshallerProblem: ToEntityMarshaller[Problem]): Problem =
+    Try(problemBody.parseJson.convertTo[Problem])
+      .getOrElse(problemOf(StatusCodes.InternalServerError, GenericError("errorMessage"))) // TODO message
+
+  private def internalServerError(
+    errorMessage: String
+  )(implicit toEntityMarshallerProblem: ToEntityMarshaller[Problem]): StandardRoute = {
+    val statusCode = StatusCodes.InternalServerError
+    complete(statusCode.intValue, problemOf(statusCode, GenericError(errorMessage)))
+  }
+}

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/error/Handlers.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/error/Handlers.scala
@@ -53,7 +53,7 @@ object Handlers {
   }
 
   private def responseToProblem(problemBody: String): Problem =
-    // Note: the body is actually a Problem of the below service, but the model is the same,
+    // Note: the body is actually a Problem of the below service, but the schema is the same,
     //   so we can convert directly to our model for convenience
     Try(problemBody.parseJson.convertTo[Problem])
       .getOrElse(problemOf(StatusCodes.InternalServerError, GenericError("Unexpected error")))

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/AgreementProcessServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/AgreementProcessServiceImpl.scala
@@ -2,17 +2,12 @@ package it.pagopa.interop.backendforfrontend.service.impl
 
 import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
 import it.pagopa.interop.agreementprocess.client.api.AgreementApi
-import it.pagopa.interop.agreementprocess.client.invoker.{ApiError, BearerToken}
+import it.pagopa.interop.agreementprocess.client.invoker.BearerToken
 import it.pagopa.interop.agreementprocess.client.model.{Agreement, AgreementPayload, AgreementState}
 import it.pagopa.interop.backendforfrontend.service.AgreementProcessService
 import it.pagopa.interop.backendforfrontend.service.types.AttributeRegistryServiceTypes.AgreementProcessInvoker
 import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
 import it.pagopa.interop.commons.utils.TypeConversions.EitherOps
-import it.pagopa.interop.commons.utils.errors.GenericComponentErrors.{
-  GenericClientError,
-  ResourceNotFoundError,
-  ThirdPartyCallError
-}
 import it.pagopa.interop.commons.utils.extractHeaders
 
 import java.util.UUID
@@ -24,9 +19,6 @@ final case class AgreementProcessServiceImpl(invoker: AgreementProcessInvoker, a
 
   private implicit val logger: LoggerTakingImplicit[ContextFieldsToLog] =
     Logger.takingImplicit[ContextFieldsToLog](this.getClass)
-
-  private val serviceName: String     = "agreement-process"
-  private val missingEntityId: String = "NoIdentifier"
 
   override def createAgreement(seed: AgreementPayload)(implicit contexts: Seq[(String, String)]): Future[Agreement] =
     for {
@@ -45,10 +37,7 @@ final case class AgreementProcessServiceImpl(invoker: AgreementProcessInvoker, a
         agreementId = agreementId.toString,
         xForwardedFor = ip
       )(BearerToken(bearerToken))
-      result <- invoker.invoke(
-        request,
-        s"Retrieving agreement $agreementId",
-      )
+      result <- invoker.invoke(request, s"Retrieving agreement $agreementId")
     } yield result
 
   override def getAgreements(
@@ -80,10 +69,7 @@ final case class AgreementProcessServiceImpl(invoker: AgreementProcessInvoker, a
       request = api.activateAgreement(xCorrelationId = correlationId, agreementId = agreementId, xForwardedFor = ip)(
         BearerToken(bearerToken)
       )
-      result <- invoker.invoke(
-        request,
-        s"Activating agreement $agreementId",
-      )
+      result <- invoker.invoke(request, s"Activating agreement $agreementId")
     } yield result
 
   override def submitAgreement(agreementId: UUID)(implicit contexts: Seq[(String, String)]): Future[Agreement] =
@@ -92,10 +78,7 @@ final case class AgreementProcessServiceImpl(invoker: AgreementProcessInvoker, a
       request = api.submitAgreement(xCorrelationId = correlationId, agreementId = agreementId, xForwardedFor = ip)(
         BearerToken(bearerToken)
       )
-      result <- invoker.invoke(
-        request,
-        s"Submitting agreement $agreementId",
-      )
+      result <- invoker.invoke(request, s"Submitting agreement $agreementId")
     } yield result
 
   override def suspendAgreement(agreementId: UUID)(implicit contexts: Seq[(String, String)]): Future[Agreement] =
@@ -104,10 +87,7 @@ final case class AgreementProcessServiceImpl(invoker: AgreementProcessInvoker, a
       request = api.suspendAgreement(xCorrelationId = correlationId, agreementId = agreementId, xForwardedFor = ip)(
         BearerToken(bearerToken)
       )
-      result <- invoker.invoke(
-        request,
-        s"Suspending agreement $agreementId",
-      )
+      result <- invoker.invoke(request, s"Suspending agreement $agreementId")
     } yield result
 
   override def upgradeAgreement(agreementId: UUID)(implicit contexts: Seq[(String, String)]): Future[Agreement] =

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/AgreementProcessServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/AgreementProcessServiceImpl.scala
@@ -34,7 +34,7 @@ final case class AgreementProcessServiceImpl(invoker: AgreementProcessInvoker, a
       request = api.createAgreement(xCorrelationId = correlationId, agreementPayload = seed, xForwardedFor = ip)(
         BearerToken(bearerToken)
       )
-      result <- invoker.invoke(request, s"Creating agreement with seed $seed", invocationRecovery(None))
+      result <- invoker.invoke(request, s"Creating agreement with seed $seed")
     } yield result
 
   override def getAgreementById(agreementId: UUID)(implicit contexts: Seq[(String, String)]): Future[Agreement] =
@@ -48,7 +48,6 @@ final case class AgreementProcessServiceImpl(invoker: AgreementProcessInvoker, a
       result <- invoker.invoke(
         request,
         s"Retrieving agreement $agreementId",
-        invocationRecovery(Some(agreementId.toString))
       )
     } yield result
 
@@ -72,7 +71,7 @@ final case class AgreementProcessServiceImpl(invoker: AgreementProcessInvoker, a
         latest = latest,
         xForwardedFor = ip
       )(BearerToken(bearerToken))
-      result <- invoker.invoke(request, s"Retrieving agreements", invocationRecovery(None))
+      result <- invoker.invoke(request, s"Retrieving agreements")
     } yield result
 
   override def activateAgreement(agreementId: UUID)(implicit contexts: Seq[(String, String)]): Future[Agreement] =
@@ -84,7 +83,6 @@ final case class AgreementProcessServiceImpl(invoker: AgreementProcessInvoker, a
       result <- invoker.invoke(
         request,
         s"Activating agreement $agreementId",
-        invocationRecovery(Some(agreementId.toString))
       )
     } yield result
 
@@ -97,7 +95,6 @@ final case class AgreementProcessServiceImpl(invoker: AgreementProcessInvoker, a
       result <- invoker.invoke(
         request,
         s"Submitting agreement $agreementId",
-        invocationRecovery(Some(agreementId.toString))
       )
     } yield result
 
@@ -110,7 +107,6 @@ final case class AgreementProcessServiceImpl(invoker: AgreementProcessInvoker, a
       result <- invoker.invoke(
         request,
         s"Suspending agreement $agreementId",
-        invocationRecovery(Some(agreementId.toString))
       )
     } yield result
 
@@ -120,26 +116,7 @@ final case class AgreementProcessServiceImpl(invoker: AgreementProcessInvoker, a
       request = api.upgradeAgreementById(xCorrelationId = correlationId, agreementId = agreementId, xForwardedFor = ip)(
         BearerToken(bearerToken)
       )
-      result <- invoker.invoke(
-        request,
-        s"Upgrading agreement $agreementId",
-        invocationRecovery(Some(agreementId.toString))
-      )
+      result <- invoker.invoke(request, s"Upgrading agreement $agreementId")
     } yield result
-
-  private def invocationRecovery[T](
-    entityId: Option[String]
-  ): (ContextFieldsToLog, LoggerTakingImplicit[ContextFieldsToLog], String) => PartialFunction[Throwable, Future[T]] =
-    (context, logger, msg) => {
-      case ex @ ApiError(code, message, _, _, _) if code == 404 =>
-        logger.error(s"$msg. code > $code - message > $message", ex)(context)
-        Future.failed[T](ResourceNotFoundError(entityId.getOrElse(missingEntityId)))
-      case ex @ ApiError(code, message, _, _, _)                =>
-        logger.error(s"$msg. code > $code - message > $message", ex)(context)
-        Future.failed[T](ThirdPartyCallError(serviceName, ex.getMessage))
-      case ex                                                   =>
-        logger.error(s"$msg. Error: ${ex.getMessage}", ex)(context)
-        Future.failed[T](GenericClientError(ex.getMessage))
-    }
 
 }

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/AttributeRegistryManagementServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/AttributeRegistryManagementServiceImpl.scala
@@ -3,7 +3,7 @@ package it.pagopa.interop.backendforfrontend.service.impl
 import cats.implicits.catsSyntaxOptionId
 import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
 import it.pagopa.interop.attributeregistrymanagement.client.api.AttributeApi
-import it.pagopa.interop.attributeregistrymanagement.client.invoker.{ApiError, BearerToken}
+import it.pagopa.interop.attributeregistrymanagement.client.invoker.BearerToken
 import it.pagopa.interop.attributeregistrymanagement.client.model.AttributesResponse
 import it.pagopa.interop.backendforfrontend.service.AttributeRegistryManagementService
 import it.pagopa.interop.backendforfrontend.service.types.AttributeRegistryServiceTypes.{
@@ -14,12 +14,6 @@ import it.pagopa.interop.backendforfrontend.service.types.AttributeRegistryServi
 }
 import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
 import it.pagopa.interop.commons.utils.TypeConversions.EitherOps
-import it.pagopa.interop.commons.utils.errors.GenericComponentErrors.{
-  GenericClientError,
-  ResourceConflictError,
-  ResourceNotFoundError,
-  ThirdPartyCallError
-}
 import it.pagopa.interop.commons.utils.extractHeaders
 
 import java.util.UUID
@@ -32,16 +26,13 @@ final case class AttributeRegistryManagementServiceImpl(invoker: AttributeRegist
   private implicit val logger: LoggerTakingImplicit[ContextFieldsToLog] =
     Logger.takingImplicit[ContextFieldsToLog](this.getClass)
 
-  private val replacementEntityId: String = "NoIdentifier"
-  private val serviceName: String         = "attribute-registry"
-
   override def getAttributes(
     search: Option[String]
   )(implicit contexts: Seq[(String, String)]): Future[AttributesResponse] = {
     for {
       (bearerToken, correlationId, ip) <- extractHeaders(contexts).toFuture
       request = api.getAttributes(xCorrelationId = correlationId, xForwardedFor = ip)(BearerToken(bearerToken))
-      result <- invoker.invoke(request, s"Loading attributes", invocationRecovery(search))
+      result <- invoker.invoke(request, s"Loading attributes")
     } yield result
   }
 
@@ -51,11 +42,7 @@ final case class AttributeRegistryManagementServiceImpl(invoker: AttributeRegist
       request = api.getAttributeById(xCorrelationId = correlationId, attributeId = attributeId, xForwardedFor = ip)(
         BearerToken(bearerToken)
       )
-      result <- invoker.invoke(
-        request,
-        s"Getting attribute by id $attributeId",
-        invocationRecovery(Some(s"Attribute $attributeId"))
-      )
+      result <- invoker.invoke(request, s"Getting attribute by id $attributeId")
     } yield result
 
   override def getAttributeByOriginAndCode(origin: String, code: String)(implicit
@@ -66,11 +53,7 @@ final case class AttributeRegistryManagementServiceImpl(invoker: AttributeRegist
       request = api.getAttributeByOriginAndCode(xCorrelationId = correlationId, origin, code, xForwardedFor = ip)(
         BearerToken(bearerToken)
       )
-      result <- invoker.invoke(
-        request,
-        s"Getting attribute by origin = $origin and code = $code",
-        invocationRecovery(Some(s"Attribute $origin/$code"))
-      )
+      result <- invoker.invoke(request, s"Getting attribute by origin = $origin and code = $code")
     } yield result
 
   override def createAttribute(
@@ -81,7 +64,7 @@ final case class AttributeRegistryManagementServiceImpl(invoker: AttributeRegist
       request = api.createAttribute(xCorrelationId = correlationId, attributeSeed = seed, xForwardedFor = ip)(
         BearerToken(bearerToken)
       )
-      result <- invoker.invoke(request, s"Creating attribute with seed $seed", invocationRecovery(Some(seed.name)))
+      result <- invoker.invoke(request, s"Creating attribute with seed $seed")
     } yield result
 
   override def getBulkAttributes(
@@ -94,29 +77,7 @@ final case class AttributeRegistryManagementServiceImpl(invoker: AttributeRegist
         ids = ids.mkString(",").some,
         xForwardedFor = ip
       )(BearerToken(bearerToken))
-      result <- invoker.invoke(
-        request,
-        s"Retrieving attribute in bulk. IDs: ${ids.mkString("[", ",", "]")}",
-        invocationRecovery(None)
-      )
+      result <- invoker.invoke(request, s"Retrieving attribute in bulk. IDs: ${ids.mkString("[", ",", "]")}")
     } yield result
-
-  private def invocationRecovery[T](
-    entityId: Option[String]
-  ): (ContextFieldsToLog, LoggerTakingImplicit[ContextFieldsToLog], String) => PartialFunction[Throwable, Future[T]] =
-    (context, logger, msg) => {
-      case ex @ ApiError(404, message, _, _, _)  =>
-        logger.error(s"$msg. code > 404 - message > $message", ex)(context)
-        Future.failed[T](ResourceNotFoundError(entityId.getOrElse(replacementEntityId)))
-      case ex @ ApiError(409, message, _, _, _)  =>
-        logger.error(s"$msg. code > 409 - message > $message", ex)(context)
-        Future.failed[T](ResourceConflictError(entityId.getOrElse(replacementEntityId)))
-      case ex @ ApiError(code, message, _, _, _) =>
-        logger.error(s"$msg. code > $code - message > $message", ex)(context)
-        Future.failed[T](ThirdPartyCallError(serviceName, ex.getMessage))
-      case ex                                    =>
-        logger.error(s"$msg. Error: ${ex.getMessage}", ex)(context)
-        Future.failed[T](GenericClientError(ex.getMessage))
-    }
 
 }

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/CatalogManagementServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/CatalogManagementServiceImpl.scala
@@ -4,15 +4,10 @@ import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
 import it.pagopa.interop.backendforfrontend.service.CatalogManagementService
 import it.pagopa.interop.backendforfrontend.service.types.AttributeRegistryServiceTypes.CatalogManagementInvoker
 import it.pagopa.interop.catalogmanagement.client.api.EServiceApi
-import it.pagopa.interop.catalogmanagement.client.invoker.{ApiError, BearerToken}
+import it.pagopa.interop.catalogmanagement.client.invoker.BearerToken
 import it.pagopa.interop.catalogmanagement.client.model.EService
 import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
 import it.pagopa.interop.commons.utils.TypeConversions.EitherOps
-import it.pagopa.interop.commons.utils.errors.GenericComponentErrors.{
-  GenericClientError,
-  ResourceNotFoundError,
-  ThirdPartyCallError
-}
 import it.pagopa.interop.commons.utils.extractHeaders
 
 import java.util.UUID
@@ -25,35 +20,13 @@ final case class CatalogManagementServiceImpl(invoker: CatalogManagementInvoker,
   private implicit val logger: LoggerTakingImplicit[ContextFieldsToLog] =
     Logger.takingImplicit[ContextFieldsToLog](this.getClass)
 
-  private val serviceName: String     = "catalog-management"
-  private val missingEntityId: String = "NoIdentifier"
-
   override def getEService(eServiceId: UUID)(implicit contexts: Seq[(String, String)]): Future[EService] =
     for {
       (bearerToken, correlationId, ip) <- extractHeaders(contexts).toFuture
       request = api.getEService(xCorrelationId = correlationId, eServiceId = eServiceId.toString, xForwardedFor = ip)(
         BearerToken(bearerToken)
       )
-      result <- invoker.invoke(
-        request,
-        s"Retrieving EService $eServiceId",
-        invocationRecovery(Some(eServiceId.toString))
-      )
+      result <- invoker.invoke(request, s"Retrieving EService $eServiceId")
     } yield result
-
-  private def invocationRecovery[T](
-    entityId: Option[String]
-  ): (ContextFieldsToLog, LoggerTakingImplicit[ContextFieldsToLog], String) => PartialFunction[Throwable, Future[T]] =
-    (context, logger, msg) => {
-      case ex @ ApiError(code, message, _, _, _) if code == 404 =>
-        logger.error(s"$msg. code > $code - message > $message", ex)(context)
-        Future.failed[T](ResourceNotFoundError(entityId.getOrElse(missingEntityId)))
-      case ex @ ApiError(code, message, _, _, _)                =>
-        logger.error(s"$msg. code > $code - message > $message", ex)(context)
-        Future.failed[T](ThirdPartyCallError(serviceName, ex.getMessage))
-      case ex                                                   =>
-        logger.error(s"$msg. Error: ${ex.getMessage}", ex)(context)
-        Future.failed[T](GenericClientError(ex.getMessage))
-    }
 
 }

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/TenantManagementServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/TenantManagementServiceImpl.scala
@@ -5,14 +5,9 @@ import it.pagopa.interop.backendforfrontend.service.TenantManagementService
 import it.pagopa.interop.backendforfrontend.service.types.AttributeRegistryServiceTypes.TenantManagementInvoker
 import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
 import it.pagopa.interop.commons.utils.TypeConversions.EitherOps
-import it.pagopa.interop.commons.utils.errors.GenericComponentErrors.{
-  GenericClientError,
-  ResourceNotFoundError,
-  ThirdPartyCallError
-}
 import it.pagopa.interop.commons.utils.extractHeaders
 import it.pagopa.interop.tenantmanagement.client.api.TenantApi
-import it.pagopa.interop.tenantmanagement.client.invoker.{ApiError, BearerToken}
+import it.pagopa.interop.tenantmanagement.client.invoker.BearerToken
 import it.pagopa.interop.tenantmanagement.client.model.Tenant
 
 import java.util.UUID
@@ -25,31 +20,13 @@ final case class TenantManagementServiceImpl(invoker: TenantManagementInvoker, a
   private implicit val logger: LoggerTakingImplicit[ContextFieldsToLog] =
     Logger.takingImplicit[ContextFieldsToLog](this.getClass)
 
-  private val serviceName: String     = "tenant-management"
-  private val missingEntityId: String = "NoIdentifier"
-
   override def getTenant(tenantId: UUID)(implicit contexts: Seq[(String, String)]): Future[Tenant] =
     for {
       (bearerToken, correlationId, ip) <- extractHeaders(contexts).toFuture
       request = api.getTenant(xCorrelationId = correlationId, tenantId = tenantId, xForwardedFor = ip)(
         BearerToken(bearerToken)
       )
-      result <- invoker.invoke(request, s"Retrieving Tenant $tenantId", invocationRecovery(Some(tenantId.toString)))
+      result <- invoker.invoke(request, s"Retrieving Tenant $tenantId")
     } yield result
-
-  private def invocationRecovery[T](
-    entityId: Option[String]
-  ): (ContextFieldsToLog, LoggerTakingImplicit[ContextFieldsToLog], String) => PartialFunction[Throwable, Future[T]] =
-    (context, logger, msg) => {
-      case ex @ ApiError(code, message, _, _, _) if code == 404 =>
-        logger.error(s"$msg. code > $code - message > $message", ex)(context)
-        Future.failed[T](ResourceNotFoundError(entityId.getOrElse(missingEntityId)))
-      case ex @ ApiError(code, message, _, _, _)                =>
-        logger.error(s"$msg. code > $code - message > $message", ex)(context)
-        Future.failed[T](ThirdPartyCallError(serviceName, ex.getMessage))
-      case ex                                                   =>
-        logger.error(s"$msg. Error: ${ex.getMessage}", ex)(context)
-        Future.failed[T](GenericClientError(ex.getMessage))
-    }
 
 }

--- a/src/test/scala/it/pagopa/interop/backendforfrontend/AuthorizationApiServiceSpec.scala
+++ b/src/test/scala/it/pagopa/interop/backendforfrontend/AuthorizationApiServiceSpec.scala
@@ -81,7 +81,7 @@ class AuthorizationApiServiceSpec extends AnyWordSpecLike with SpecHelper with S
         Seq.empty,
         toEntityMarshallerSessionToken
       ) ~> check {
-        responseAs[Problem].errors.map(_.code) should contain theSameElementsAs Seq("016-0001")
+        responseAs[Problem].errors.map(_.code) should contain theSameElementsAs Seq("016-9991")
       }
     }
 
@@ -127,7 +127,7 @@ class AuthorizationApiServiceSpec extends AnyWordSpecLike with SpecHelper with S
         Seq.empty,
         toEntityMarshallerSessionToken
       ) ~> check {
-        responseAs[Problem].errors.map(_.code) should contain theSameElementsAs Seq("016-0001")
+        responseAs[Problem].errors.map(_.code) should contain theSameElementsAs Seq("016-9991")
       }
     }
 

--- a/src/test/scala/it/pagopa/interop/backendforfrontend/ErrorHandlerSpec.scala
+++ b/src/test/scala/it/pagopa/interop/backendforfrontend/ErrorHandlerSpec.scala
@@ -1,0 +1,29 @@
+package it.pagopa.interop.backendforfrontend
+
+import akka.http.scaladsl.marshalling.ToEntityMarshaller
+import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
+import it.pagopa.interop.backendforfrontend.api.impl.entityMarshallerProblem
+import it.pagopa.interop.backendforfrontend.error.Handlers.handleError
+import it.pagopa.interop.backendforfrontend.model.Problem
+import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class ErrorHandlerSpec extends AnyWordSpecLike {
+
+  implicit val contexts: Seq[(String, String)]                  = Nil
+  implicit val logger: LoggerTakingImplicit[ContextFieldsToLog] =
+    Logger.takingImplicit[ContextFieldsToLog](this.getClass)
+  implicit val problemMarshaller: ToEntityMarshaller[Problem]   = entityMarshallerProblem
+
+  "Error Handler" should {
+    "handle Agreement Process error" in {
+      handleError("error message")
+    }
+
+    "handle Attribute Registry error" in {}
+    "handle Catalog Management error" in {}
+    "handle Party Process error" in {}
+    "handle Tenant Management error" in {}
+    "return generic error on unexpected error" in {}
+  }
+}

--- a/src/test/scala/it/pagopa/interop/backendforfrontend/ErrorHandlerSpec.scala
+++ b/src/test/scala/it/pagopa/interop/backendforfrontend/ErrorHandlerSpec.scala
@@ -1,29 +1,104 @@
 package it.pagopa.interop.backendforfrontend
 
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.marshalling.ToEntityMarshaller
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import akka.http.scaladsl.unmarshalling.FromEntityUnmarshaller
 import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
-import it.pagopa.interop.backendforfrontend.api.impl.entityMarshallerProblem
+import it.pagopa.interop.agreementprocess.client.invoker.{ApiError => AgreementProcessError}
+import it.pagopa.interop.attributeregistrymanagement.client.invoker.{ApiError => AttributeRegistryError}
+import it.pagopa.interop.backendforfrontend.api.impl.{entityMarshallerProblem, problemFormat, problemOf}
 import it.pagopa.interop.backendforfrontend.error.Handlers.handleError
-import it.pagopa.interop.backendforfrontend.model.Problem
+import it.pagopa.interop.backendforfrontend.model.{Problem, ProblemError}
+import it.pagopa.interop.catalogmanagement.client.invoker.{ApiError => CatalogManagementError}
 import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
+import it.pagopa.interop.commons.utils.errors.GenericComponentErrors.GenericError
+import it.pagopa.interop.selfcare.partyprocess.client.invoker.{ApiError => PartyProcessError}
+import it.pagopa.interop.selfcare.userregistry.client.invoker.{ApiError => UserRegistryError}
+import it.pagopa.interop.tenantmanagement.client.invoker.{ApiError => TenantManagementError}
+import org.scalatest.matchers.should.Matchers._
 import org.scalatest.wordspec.AnyWordSpecLike
+import spray.json._
 
-class ErrorHandlerSpec extends AnyWordSpecLike {
+import scala.util.Failure
 
-  implicit val contexts: Seq[(String, String)]                  = Nil
-  implicit val logger: LoggerTakingImplicit[ContextFieldsToLog] =
+class ErrorHandlerSpec extends AnyWordSpecLike with ScalatestRouteTest with SprayJsonSupport with DefaultJsonProtocol {
+
+  implicit val contexts: Seq[(String, String)]                                  = Nil
+  implicit val logger: LoggerTakingImplicit[ContextFieldsToLog]                 =
     Logger.takingImplicit[ContextFieldsToLog](this.getClass)
-  implicit val problemMarshaller: ToEntityMarshaller[Problem]   = entityMarshallerProblem
+  implicit val problemMarshaller: ToEntityMarshaller[Problem]                   = entityMarshallerProblem
+  implicit def fromResponseUnmarshallerProblem: FromEntityUnmarshaller[Problem] =
+    sprayJsonUnmarshaller[Problem]
+
+  val problem: Problem =
+    Problem("someType", 404, "An Error occurred", Some("These are the details"), Seq(ProblemError("0001", "det")))
 
   "Error Handler" should {
     "handle Agreement Process error" in {
-      handleError("error message")
+      val error = AgreementProcessError(404, problem.toJson.compactPrint, None)
+
+      Get() ~> handleError("error message")(contexts, logger, problemMarshaller)(Failure(error)) ~> check {
+        status.intValue shouldBe error.code
+        responseAs[Problem] shouldBe problem
+      }
     }
 
-    "handle Attribute Registry error" in {}
-    "handle Catalog Management error" in {}
-    "handle Party Process error" in {}
-    "handle Tenant Management error" in {}
-    "return generic error on unexpected error" in {}
+    "handle Attribute Registry error" in {
+      val error = AttributeRegistryError(404, problem.toJson.compactPrint, None)
+
+      Get() ~> handleError("error message")(contexts, logger, problemMarshaller)(Failure(error)) ~> check {
+        status.intValue shouldBe error.code
+        responseAs[Problem] shouldBe problem
+      }
+    }
+
+    "handle Catalog Management error" in {
+      val error = CatalogManagementError(404, problem.toJson.compactPrint, None)
+
+      Get() ~> handleError("error message")(contexts, logger, problemMarshaller)(Failure(error)) ~> check {
+        status.intValue shouldBe error.code
+        responseAs[Problem] shouldBe problem
+      }
+    }
+
+    "handle Party Process error" in {
+      val error = PartyProcessError(404, problem.toJson.compactPrint, None)
+
+      Get() ~> handleError("error message")(contexts, logger, problemMarshaller)(Failure(error)) ~> check {
+        status.intValue shouldBe error.code
+        responseAs[Problem] shouldBe problem
+      }
+    }
+
+    "handle Tenant Management error" in {
+      val error = TenantManagementError(404, problem.toJson.compactPrint, None)
+
+      Get() ~> handleError("error message")(contexts, logger, problemMarshaller)(Failure(error)) ~> check {
+        status.intValue shouldBe error.code
+        responseAs[Problem] shouldBe problem
+      }
+    }
+
+    "handle User Registry error" in {
+      val error = UserRegistryError(404, problem.toJson.compactPrint, None)
+
+      Get() ~> handleError("error message")(contexts, logger, problemMarshaller)(Failure(error)) ~> check {
+        status.intValue shouldBe error.code
+        responseAs[Problem] shouldBe problem
+      }
+    }
+
+    "return generic error on unexpected error" in {
+      val error = new Exception("I'm a generic exception")
+
+      val message = "error message"
+
+      Get() ~> handleError(message)(contexts, logger, problemMarshaller)(Failure(error)) ~> check {
+        status.intValue shouldBe 500
+        responseAs[Problem] shouldBe problemOf(StatusCodes.InternalServerError, GenericError(message))
+      }
+    }
   }
 }


### PR DESCRIPTION
A couple of points:
- In some cases this implementation could be too naive, e.g.:
  - GET `/agreements/{agreementId}`
  - agreement is found
  - agreement enrichment requests EService
  - EService is not found

  In this case a 404 is returned, while it could (should?) be a 500

- I left the current error handling for party and user registry calls, because formally they are external services and in my opinion we should not forward blindly their errors.

Let me know your thoughts 👇 