### PR TITLE
Pin 2095

### DIFF
--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -1405,7 +1405,7 @@ paths:
       - $ref: '#/components/parameters/CorrelationIdHeader'
       - $ref: '#/components/parameters/IpAddress'
     post:
-      security: [ { } ]
+      security: [{}]
       tags:
         - authorization
       operationId: getSessionToken
@@ -2583,9 +2583,192 @@ paths:
         in: path
         required: true
         description: 'code of the attribute to lookup (e.g.: unique identifier of IPA).'
+  '/tenants/{tenantId}':
+    parameters:
+      - $ref: '#/components/parameters/CorrelationIdHeader'
+      - $ref: '#/components/parameters/IpAddress'
+      - name: tenantId
+        in: path
+        description: the tenant id
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - tenants
+      summary: Updates the content of the tenant
+      description: Updates the content of the tenant
+      operationId: updateTenant
+      parameters:
+        - name: tenantId
+          in: path
+          description: The internal identifier of the tenant
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TenantDelta'
+        description: payload for tenant update
+        required: true
+      responses:
+        '204':
+          description: Tenant updated
+          headers:
+            'X-Rate-Limit-Limit':
+              schema:
+                type: integer
+              description: Max allowed requests within time interval
+            'X-Rate-Limit-Remaining':
+              schema:
+                type: integer
+              description: Remaining requests within time interval
+            'X-Rate-Limit-Interval':
+              schema:
+                type: integer
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        '404':
+          description: Tenant not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+          headers:
+            'X-Rate-Limit-Limit':
+              schema:
+                type: integer
+              description: Max allowed requests within time interval
+            'X-Rate-Limit-Remaining':
+              schema:
+                type: integer
+              description: Remaining requests within time interval
+            'X-Rate-Limit-Interval':
+              schema:
+                type: integer
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        '429':
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+          headers:
+            'X-Rate-Limit-Limit':
+              schema:
+                type: integer
+              description: Max allowed requests within time interval
+            'X-Rate-Limit-Remaining':
+              schema:
+                type: integer
+              description: Remaining requests within time interval
+            'X-Rate-Limit-Interval':
+              schema:
+                type: integer
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+  '/eservices/{eserviceId}/descriptor/{descriptorId}':
+    parameters:
+      - $ref: '#/components/parameters/CorrelationIdHeader'
+      - $ref: '#/components/parameters/IpAddress'
+      - name: eserviceId
+        in: path
+        description: the eservice id
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: descriptorId
+        in: path
+        description: the descriptor id
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - eservices
+      summary: Retrieves the eservice descriptor corresponding to the id
+      description: Retrieves the eservice descriptor corresponding to the id
+      operationId: getEserviceDescriptor
+      parameters:
+        - name: eserviceId
+          in: path
+          description: The internal identifier of the eservice
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: descriptorId
+          in: path
+          description: the descriptor id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: The corresponding eService descriptor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EServiceDescriptor'
+          headers:
+            'X-Rate-Limit-Limit':
+              schema:
+                type: integer
+              description: Max allowed requests within time interval
+            'X-Rate-Limit-Remaining':
+              schema:
+                type: integer
+              description: Remaining requests within time interval
+            'X-Rate-Limit-Interval':
+              schema:
+                type: integer
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        '404':
+          description: Eservice not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+          headers:
+            'X-Rate-Limit-Limit':
+              schema:
+                type: integer
+              description: Max allowed requests within time interval
+            'X-Rate-Limit-Remaining':
+              schema:
+                type: integer
+              description: Remaining requests within time interval
+            'X-Rate-Limit-Interval':
+              schema:
+                type: integer
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
+        '429':
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Problem'
+          headers:
+            'X-Rate-Limit-Limit':
+              schema:
+                type: integer
+              description: Max allowed requests within time interval
+            'X-Rate-Limit-Remaining':
+              schema:
+                type: integer
+              description: Remaining requests within time interval
+            'X-Rate-Limit-Interval':
+              schema:
+                type: integer
+              description: Time interval in milliseconds. Allowed requests will be constantly replenished during the interval. At the end of the interval the max allowed requests will be available
   /status:
     get:
-      security: [ ]
+      security: []
       tags:
         - health
       summary: Health status endpoint
@@ -2612,6 +2795,91 @@ components:
       schema:
         type: string
   schemas:
+    Mail:
+      type: object
+      required:
+        - address
+      properties:
+        address:
+          type: string
+        description:
+          type: string
+    EServiceDescriptor:
+      type: object
+      required:
+        - id
+        - version
+        - docs
+        - state
+        - creationDate
+        - audience
+        - voucherLifespan
+        - dailyCallsPerConsumer
+        - dailyCallsTotal
+        - agreementApprovalPolicy
+      properties:
+        id:
+          type: string
+          format: uuid
+        version:
+          type: string
+        description:
+          type: string
+        interface:
+          $ref: '#/components/schemas/EServiceDoc'
+        docs:
+          type: array
+          items:
+            $ref: '#/components/schemas/EServiceDoc'
+        state:
+          $ref: '#/components/schemas/EServiceDescriptorState'
+        audience:
+          type: array
+          items:
+            type: string
+        voucherLifespan:
+          type: integer
+          format: int32
+        dailyCallsPerConsumer:
+          description: 'maximum number of daily calls that this descriptor can afford.'
+          type: integer
+          format: int32
+          minimum: 0
+        dailyCallsTotal:
+          description: 'total daily calls available for this e-service.'
+          type: integer
+          format: int32
+          minimum: 0
+        agreementApprovalPolicy:
+          $ref: '#/components/schemas/AgreementApprovalPolicy'
+        mail:
+          $ref: '#/components/schemas/Mail'
+    EServiceDoc:
+      type: object
+      required:
+        - id
+        - name
+        - contentType
+        - prettyName
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        contentType:
+          type: string
+        prettyName:
+          type: string
+    AgreementApprovalPolicy:
+      type: string
+      description: |
+        EService Descriptor policy for new Agreements approval.
+        AUTOMATIC - the agreement will be automatically approved if Consumer attributes are met
+        MANUAL - the Producer must approve every agreement for this Descriptor.
+      enum:
+        - AUTOMATIC
+        - MANUAL
     Agreement:
       properties:
         id:
@@ -2625,7 +2893,7 @@ components:
         consumer:
           $ref: '#/components/schemas/TenantWithAttributes'
         eservice:
-          $ref: '#/components/schemas/EService'
+          $ref: '#/components/schemas/AgreementsEService'
         state:
           $ref: '#/components/schemas/AgreementState'
         verifiedAttributes:
@@ -2694,6 +2962,16 @@ components:
       required:
         - eserviceId
         - descriptorId
+    TenantDelta:
+      description: Tenant Delta model
+      type: object
+      properties:
+        contactEmail:
+          type: string
+        description:
+          type: string
+      required:
+        - contactEmail
     AgreementSubmissionPayload:
       type: object
       description: contains the information for agreement creation.
@@ -2933,7 +3211,7 @@ components:
         createdAt:
           type: string
           format: date-time
-    EService:
+    AgreementsEService:
       properties:
         id:
           type: string

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/AgreementsApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/AgreementsApiServiceImpl.scala
@@ -62,10 +62,7 @@ final case class AgreementsApiServiceImpl(
     onComplete(result) {
       handleError(
         s"Error creating agreement for EService ${payload.eserviceId} and Descriptor ${payload.descriptorId}"
-      ) orElse { case Success(resource) =>
-        createAgreement200(resource)
-
-      }
+      ) orElse { case Success(resource) => createAgreement200(resource) }
     }
   }
 
@@ -261,7 +258,7 @@ final case class AgreementsApiServiceImpl(
     producer = Tenant(id = agreement.producerId, name = producerDescription),
     consumer =
       TenantWithAttributes(id = agreement.consumerId, name = consumerDescription, attributes = tenantAttributes),
-    eservice = EService(
+    eservice = AgreementsEService(
       id = agreement.eserviceId,
       name = eService.name,
       version = currentDescriptor.version,

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiMarshallerImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiMarshallerImpl.scala
@@ -8,6 +8,9 @@ import spray.json.DefaultJsonProtocol
 
 object EServicesApiMarshallerImpl extends EservicesApiMarshaller with SprayJsonSupport with DefaultJsonProtocol {
 
+  override implicit def toEntityMarshallerEServiceDescriptor: ToEntityMarshaller[EServiceDescriptor] =
+    sprayJsonMarshaller[EServiceDescriptor]
+
   override implicit def toEntityMarshallerProblem: ToEntityMarshaller[Problem] = entityMarshallerProblem
 
   override implicit def toEntityMarshallerCatalogEServices: ToEntityMarshaller[CatalogEServices] =

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
@@ -12,6 +12,7 @@ import it.pagopa.interop.backendforfrontend.error.Handlers.handleError
 import it.pagopa.interop.backendforfrontend.model._
 import it.pagopa.interop.backendforfrontend.service.types.AgreementProcessServiceTypes._
 import it.pagopa.interop.backendforfrontend.service.types.CatalogProcessServiceTypes._
+import it.pagopa.interop.backendforfrontend.service.types.TenantManagementServiceTypes._
 import it.pagopa.interop.backendforfrontend.service.{
   AgreementProcessService,
   CatalogProcessService,
@@ -26,7 +27,9 @@ import it.pagopa.interop.commons.utils.TypeConversions._
 
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Success
+import scala.util.{Failure, Success}
+import it.pagopa.interop.backendforfrontend.error.BFFErrors._
+import akka.http.scaladsl.model.StatusCodes
 
 final case class EServicesApiServiceImpl(
   agreementProcessService: AgreementProcessService,
@@ -44,6 +47,32 @@ final case class EServicesApiServiceImpl(
     CatalogProcess.EServiceDescriptorState.SUSPENDED,
     CatalogProcess.EServiceDescriptorState.DEPRECATED
   )
+
+  override def getEserviceDescriptor(eserviceId: String, descriptorId: String)(implicit
+    contexts: Seq[(String, String)],
+    toEntityMarshallerEServiceDescriptor: ToEntityMarshaller[EServiceDescriptor],
+    toEntityMarshallerProblem: ToEntityMarshaller[Problem]
+  ): Route = {
+    val result: Future[EServiceDescriptor] = for {
+      (eserviceUUID, descriptorUUID) <- eserviceId.toFutureUUID.zip(descriptorId.toFutureUUID)
+      eService                       <- catalogProcessService.getEServiceById(eserviceUUID)
+      descriptor                     <- eService.descriptors
+        .find(_.id === descriptorUUID)
+        .toFuture(EServiceDescriptorNotFound(eserviceId, descriptorId))
+      mail                           <- tenantManagementService
+        .getTenant(eService.producer.id)
+        .map(_.mails.headOption.map(_.toApi))
+    } yield descriptor.toApi(mail)
+
+    onComplete(result) {
+      handleError(s"Error retrieving descriptor $descriptorId of eservice $eserviceId") orElse {
+        case Failure(x: EServiceDescriptorNotFound) =>
+          logger.warn(x.getMessage)
+          getEserviceDescriptor404(problemOf(StatusCodes.NotFound, x))
+        case Success(descriptor)                    => getEserviceDescriptor200(descriptor)
+      }
+    }
+  }
 
   override def getEServicesCatalog(q: Option[String], producersIds: String, states: String, offset: Int, limit: Int)(
     implicit

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/TenantsApiMarshallerImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/TenantsApiMarshallerImpl.scala
@@ -13,6 +13,7 @@ import it.pagopa.interop.backendforfrontend.model.{
   VerifiedTenantAttributeSeed
 }
 import spray.json.DefaultJsonProtocol
+import it.pagopa.interop.backendforfrontend.model.TenantDelta
 
 object TenantsApiMarshallerImpl extends TenantsApiMarshaller with SprayJsonSupport with DefaultJsonProtocol {
 
@@ -32,4 +33,8 @@ object TenantsApiMarshallerImpl extends TenantsApiMarshaller with SprayJsonSuppo
 
   override implicit def toEntityMarshallerDeclaredAttributesResponse: ToEntityMarshaller[DeclaredAttributesResponse] =
     sprayJsonMarshaller[DeclaredAttributesResponse]
+
+  override implicit def fromEntityUnmarshallerTenantDelta: FromEntityUnmarshaller[TenantDelta] =
+    sprayJsonUnmarshaller[TenantDelta]
+
 }

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/TenantsApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/TenantsApiServiceImpl.scala
@@ -128,6 +128,23 @@ final case class TenantsApiServiceImpl(
     }
   }
 
+  override def updateTenant(tenantId: String, tenantDelta: TenantDelta)(implicit
+    contexts: Seq[(String, String)],
+    toEntityMarshallerProblem: ToEntityMarshaller[Problem]
+  ): Route = {
+    val result: Future[Unit] = for {
+      tenantUUID <- tenantId.toFutureUUID
+      tenant     <- tenantProcessService.getTenant(tenantUUID)
+      ()         <- tenantProcessService.updateTenant(tenantUUID, tenantDelta.toExternalModel(tenant))
+    } yield ()
+
+    onComplete(result) {
+      handleError(s"Error updating tenant with id $tenantId") orElse { case Success(_) =>
+        updateTenant204
+      }
+    }
+  }
+
   private def getTenantAttributes[DepAttribute, ApiAttribute](
     tenantId: String,
     attributeFromTenantAttribute: DepTenantAttribute => Option[DepAttribute]

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/package.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/package.scala
@@ -17,6 +17,12 @@ import scala.concurrent.{ExecutionContext, Future}
 
 package object impl extends SprayJsonSupport with DefaultJsonProtocol {
 
+  implicit val eServiceDocFormat: RootJsonFormat[EServiceDoc]               = jsonFormat4(EServiceDoc)
+  implicit val mailFormat: RootJsonFormat[Mail]                             = jsonFormat2(Mail)
+  implicit val eServiceDescriptorFormat: RootJsonFormat[EServiceDescriptor] = jsonFormat12(EServiceDescriptor)
+
+  implicit val tenantDelta: RootJsonFormat[TenantDelta] = jsonFormat2(TenantDelta)
+
   implicit val tenantFormat: RootJsonFormat[Tenant] = jsonFormat2(Tenant)
 
   implicit val paginationFormat: RootJsonFormat[Pagination] = jsonFormat3(Pagination)
@@ -44,7 +50,7 @@ package object impl extends SprayJsonSupport with DefaultJsonProtocol {
 
   implicit val tenantWithAttributesFormat: RootJsonFormat[TenantWithAttributes] = jsonFormat3(TenantWithAttributes)
   implicit val activeDescriptorFormat: RootJsonFormat[ActiveDescriptor]         = jsonFormat3(ActiveDescriptor)
-  implicit val eServiceFormat: RootJsonFormat[EService]                         = jsonFormat4(EService)
+  implicit val agreementsEServiceFormat: RootJsonFormat[AgreementsEService]     = jsonFormat4(AgreementsEService)
 
   implicit val documentFormat: RootJsonFormat[Document] = jsonFormat5(Document)
 

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/error/BFFErrors.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/error/BFFErrors.scala
@@ -25,6 +25,9 @@ object BFFErrors {
   final case class ContractNotFound(agreementId: String)
       extends ComponentError("0007", s"Contract not found for agreement $agreementId")
 
+  final case class EServiceDescriptorNotFound(eServiceId: String, descriptorId: String)
+      extends ComponentError("0008", s"Descriptor ${descriptorId} not found in Eservice ${eServiceId}")
+
   final case class InvalidContentType(
     contentType: String,
     agreementId: String,

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/CatalogProcessService.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/CatalogProcessService.scala
@@ -1,7 +1,7 @@
 package it.pagopa.interop.backendforfrontend.service
 
 import it.pagopa.interop.catalogprocess.client.model._
-
+import java.util.UUID
 import scala.concurrent.Future
 
 trait CatalogProcessService {
@@ -14,4 +14,5 @@ trait CatalogProcessService {
     limit: Int
   )(implicit contexts: Seq[(String, String)]): Future[EServices]
 
+  def getEServiceById(eServiceId: UUID)(implicit contexts: Seq[(String, String)]): Future[OldEService]
 }

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/TenantProcessService.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/TenantProcessService.scala
@@ -19,4 +19,8 @@ trait TenantProcessService {
   def revokeVerifiedAttribute(tenantId: UUID, attributeId: UUID)(implicit
     contexts: Seq[(String, String)]
   ): Future[Tenant]
+
+  def getTenant(tenantId: UUID)(implicit contexts: Seq[(String, String)]): Future[Tenant]
+
+  def updateTenant(tenantId: UUID, tenantDelta: TenantDelta)(implicit contexts: Seq[(String, String)]): Future[Unit]
 }

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/CatalogProcessServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/CatalogProcessServiceImpl.scala
@@ -1,15 +1,16 @@
 package it.pagopa.interop.backendforfrontend.service.impl
 
 import akka.actor.typed.ActorSystem
-import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
 import it.pagopa.interop.backendforfrontend.service.CatalogProcessService
 import it.pagopa.interop.catalogprocess.client.api.{EnumsSerializers, ProcessApi}
 import it.pagopa.interop.catalogprocess.client.invoker.{ApiInvoker, ApiRequest, BearerToken}
 import it.pagopa.interop.catalogprocess.client.model.{EServiceDescriptorState, EServices}
 import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
 import it.pagopa.interop.commons.utils.withHeaders
-
 import scala.concurrent.{ExecutionContextExecutor, Future}
+import com.typesafe.scalalogging.{Logger, LoggerTakingImplicit}
+import java.util.UUID
+import it.pagopa.interop.catalogprocess.client.model.OldEService
 
 class CatalogProcessServiceImpl(catalogProcessUrl: String, blockingEc: ExecutionContextExecutor)(implicit
   system: ActorSystem[_]
@@ -42,6 +43,15 @@ class CatalogProcessServiceImpl(catalogProcessUrl: String, blockingEc: Execution
         request,
         s"Retrieving EServices for name = $name, producersIds = $producersIds, states = $states, offset = $offset, limit = $limit,"
       )
+    }
+
+  override def getEServiceById(eServiceId: UUID)(implicit contexts: Seq[(String, String)]): Future[OldEService] =
+    withHeaders { (bearerToken, correlationId, ip) =>
+      val request: ApiRequest[OldEService] =
+        api.getEServiceById(xCorrelationId = correlationId, eServiceId = eServiceId.toString, xForwardedFor = ip)(
+          BearerToken(bearerToken)
+        )
+      invoker.invoke(request, s"Retrieving EService for $eServiceId from Catalog Process")
     }
 
 }

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/TenantProcessServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/impl/TenantProcessServiceImpl.scala
@@ -19,6 +19,7 @@ import scala.concurrent.{ExecutionContextExecutor, Future}
 import it.pagopa.interop.tenantprocess.client.invoker.ApiRequest
 import akka.actor.typed.ActorSystem
 import it.pagopa.interop.commons.utils.withHeaders
+import it.pagopa.interop.tenantprocess.client.model.TenantDelta
 
 class TenantProcessServiceImpl(tenantprocessUrl: String, blockingEc: ExecutionContextExecutor)(implicit
   system: ActorSystem[_]
@@ -90,4 +91,22 @@ class TenantProcessServiceImpl(tenantprocessUrl: String, blockingEc: ExecutionCo
         )(BearerToken(bearerToken))
       invoker.invoke(request, s"Revoking verified attribute $attributeId to $tenantId")
     }
+
+  override def updateTenant(tenantId: UUID, tenantDelta: TenantDelta)(implicit
+    contexts: Seq[(String, String)]
+  ): Future[Unit] = withHeaders[Unit] { (bearerToken, correlationId, ip) =>
+    val request: ApiRequest[Tenant] =
+      api.updateTenant(xCorrelationId = correlationId, xForwardedFor = ip, id = tenantId, tenantDelta = tenantDelta)(
+        BearerToken(bearerToken)
+      )
+    invoker.invoke(request, s"Updating tenant with id $tenantId").map(_ => ())(blockingEc)
+  }
+
+  override def getTenant(tenantId: UUID)(implicit contexts: Seq[(String, String)]): Future[Tenant] =
+    withHeaders[Tenant] { (bearerToken, correlationId, ip) =>
+      val request: ApiRequest[Tenant] =
+        api.getTenant(xCorrelationId = correlationId, xForwardedFor = ip, id = tenantId)(BearerToken(bearerToken))
+      invoker.invoke(request, s"Getting tenant with id $tenantId")
+    }
+
 }

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/types/CatalogProcessServiceTypes.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/types/CatalogProcessServiceTypes.scala
@@ -51,4 +51,35 @@ object CatalogProcessServiceTypes {
     def toManagement: CatalogManagement.AttributeValue =
       CatalogManagement.AttributeValue(id = a.id, explicitAttributeVerification = a.explicitAttributeVerification)
   }
+
+  implicit class AgreementApprovalPolicyWrapper(private val aap: CatalogProcess.AgreementApprovalPolicy)
+      extends AnyVal {
+    def toApi: AgreementApprovalPolicy = aap match {
+      case CatalogProcess.AgreementApprovalPolicy.AUTOMATIC => AgreementApprovalPolicy.AUTOMATIC
+      case CatalogProcess.AgreementApprovalPolicy.MANUAL    => AgreementApprovalPolicy.MANUAL
+    }
+  }
+
+  implicit class EServiceDocWrapper(private val esd: CatalogProcess.EServiceDoc) extends AnyVal {
+    def toApi: EServiceDoc =
+      EServiceDoc(id = esd.id, name = esd.name, contentType = esd.contentType, prettyName = esd.prettyName)
+  }
+
+  implicit class EServiceDescriptorWrapper(private val esd: CatalogProcess.EServiceDescriptor) extends AnyVal {
+    def toApi(mail: Option[Mail]): EServiceDescriptor = EServiceDescriptor(
+      id = esd.id,
+      version = esd.version,
+      description = esd.description,
+      interface = esd.interface.map(_.toApi),
+      docs = esd.docs.map(_.toApi),
+      state = esd.state.toApi,
+      audience = esd.audience,
+      voucherLifespan = esd.voucherLifespan,
+      dailyCallsPerConsumer = esd.dailyCallsPerConsumer,
+      dailyCallsTotal = esd.dailyCallsTotal,
+      agreementApprovalPolicy = esd.agreementApprovalPolicy.toApi,
+      mail = mail
+    )
+  }
+
 }

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/types/TenantManagementServiceTypes.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/types/TenantManagementServiceTypes.scala
@@ -110,4 +110,8 @@ object TenantManagementServiceTypes {
       revocationDate = v.revocationDate
     )
   }
+
+  implicit class MailConverter(private val m: TenantManagement.Mail) extends AnyVal {
+    def toApi: Mail = Mail(address = m.address, description = m.description)
+  }
 }

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/types/TenantProcessServiceTypes.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/types/TenantProcessServiceTypes.scala
@@ -17,6 +17,18 @@ object TenantProcessServiceTypes {
     )
   }
 
+  implicit class TenantDeltaConverter(private val delta: TenantDelta) extends AnyVal {
+    def toExternalModel(tenant: TenantProcess.Tenant): TenantProcess.TenantDelta = TenantProcess.TenantDelta(
+      selfcareId = tenant.selfcareId,
+      features = tenant.features,
+      mails = TenantProcess.MailSeed(
+        kind = TenantProcess.MailKind.CONTACT_EMAIL,
+        address = delta.contactEmail,
+        description = delta.description
+      ) :: Nil
+    )
+  }
+
   implicit class VerificationRenewalConverter(private val v: VerificationRenewal) extends AnyVal {
     def toSeed: TenantProcess.VerificationRenewal = v match {
       case VerificationRenewal.REVOKE_ON_EXPIRATION => TenantProcess.VerificationRenewal.REVOKE_ON_EXPIRATION

--- a/src/test/scala/it/pagopa/interop/backendforfrontend/AuthorizationApiServiceSpec.scala
+++ b/src/test/scala/it/pagopa/interop/backendforfrontend/AuthorizationApiServiceSpec.scala
@@ -186,7 +186,8 @@ class AuthorizationApiServiceSpec extends AnyWordSpecLike with SpecHelper with S
               features = Nil,
               attributes = Nil,
               createdAt = OffsetDateTimeSupplier.get(),
-              updatedAt = None
+              updatedAt = None,
+              mails = Nil
             )
           )
         )


### PR DESCRIPTION
This PR depends on both https://github.com/pagopa/interop-be-tenant-management/pull/43 and https://github.com/pagopa/interop-be-tenant-process/pull/31 

Here were added:
- the `/tenants/{tenantId}` endpoint in POST to update the tenant's mail (exposed as a single one and not like in the persistence model where is a list of mails)
- the `/eservices/{eserviceId}/descriptor/{descriptorId}` endpoint in GET that retrieves the information from the catalog process and decorates it using the tenant-management informations.