### PR TITLE
pin-2793: Fix agreement consumer documents path

### DIFF
--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/AgreementsApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/AgreementsApiServiceImpl.scala
@@ -376,12 +376,12 @@ final case class AgreementsApiServiceImpl(
     logger.info(s"Adding consumer document to agreement $agreementId")
 
     val documentId: UUID         = uuidSupplier.get()
-    val documentPath: String     = s"${ApplicationConfiguration.consumerDocumentsPath}/$agreementId/$documentId"
+    val documentPath: String     = s"${ApplicationConfiguration.consumerDocumentsPath}/$agreementId"
     val result: Future[Document] =
       for {
         agreementUUID <- agreementId.toFutureUUID
         seed          <- fileManager
-          .store(ApplicationConfiguration.consumerDocumentsContainer, documentPath)(doc._1.fileName, doc)
+          .store(ApplicationConfiguration.consumerDocumentsContainer, documentPath)(documentId.toString, doc)
           .map(path =>
             AgreementProcess.DocumentSeed(
               id = documentId,


### PR DESCRIPTION
Example
- Agreement id `A1`
- Document id `D1`
- Filename `F1`

Old path: `A1/D1/F1/F1`
New Path: `A1/D1/F1`

This change should be retro-compatible, because old files will maintain the old path, that is stored in the agreement object