### PR TITLE
fix: Move riskAnalysisId to form

### DIFF
--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -10306,7 +10306,7 @@ components:
         name:
           type: string
         riskAnalysisForm:
-          $ref: '#/components/schemas/RiskAnalysisForm'
+          $ref: '#/components/schemas/RiskAnalysisFormSeed'
     EServiceRiskAnalysis:
       type: object
       required:
@@ -10755,7 +10755,7 @@ components:
           type: string
           format: uuid
         riskAnalysisForm:
-          $ref: '#/components/schemas/RiskAnalysisForm'
+          $ref: '#/components/schemas/RiskAnalysisFormSeed'
         title:
           type: string
         description:
@@ -11008,9 +11008,6 @@ components:
           type: string
         consumer:
           $ref: '#/components/schemas/CompactOrganization'
-        riskAnalysisId:
-          type: string
-          format: uuid
         riskAnalysisForm:
           $ref: '#/components/schemas/RiskAnalysisForm'
         eservice:
@@ -11210,7 +11207,7 @@ components:
         freeOfChargeReason:
           type: string      
         riskAnalysisForm:
-          $ref: '#/components/schemas/RiskAnalysisForm'
+          $ref: '#/components/schemas/RiskAnalysisFormSeed'
         dailyCalls:
           description: 'maximum number of daily calls that this version can perform.'
           type: integer
@@ -11389,6 +11386,26 @@ components:
             type: array
             items:
               type: string
+        riskAnalysisId:
+          type: string
+          format: uuid
+      required:
+        - version
+        - answers
+    RiskAnalysisFormSeed:
+      type: object
+      properties:
+        version:
+          type: string
+          minLength: 1
+          maxLength: 250
+        answers:
+          additionalProperties:
+            type: array
+            items:
+              type: string
+              minLength: 1
+              maxLength: 250
       required:
         - version
         - answers

--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -11397,15 +11397,11 @@ components:
       properties:
         version:
           type: string
-          minLength: 1
-          maxLength: 250
         answers:
           additionalProperties:
             type: array
             items:
               type: string
-              minLength: 1
-              maxLength: 250
       required:
         - version
         - answers

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/package.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/package.scala
@@ -116,7 +116,8 @@ package object impl extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val eServiceAttributeFormat: RootJsonFormat[DescriptorAttribute]   = jsonFormat4(DescriptorAttribute)
   implicit val eServiceAttributesFormat: RootJsonFormat[DescriptorAttributes] = jsonFormat3(DescriptorAttributes)
 
-  implicit val riskAnalysisFormFormat: RootJsonFormat[RiskAnalysisForm] = jsonFormat2(RiskAnalysisForm)
+  implicit val riskAnalysisFormFormat: RootJsonFormat[RiskAnalysisForm]         = jsonFormat3(RiskAnalysisForm)
+  implicit val riskAnalysisFormSeedFormat: RootJsonFormat[RiskAnalysisFormSeed] = jsonFormat2(RiskAnalysisFormSeed)
 
   implicit val eServiceRiskAnalysisFormat: RootJsonFormat[EServiceRiskAnalysis] =
     jsonFormat4(EServiceRiskAnalysis)
@@ -149,7 +150,7 @@ package object impl extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val clientPurposeFormat: RootJsonFormat[ClientPurpose]                   = jsonFormat3(ClientPurpose)
   implicit val clientFormat: RootJsonFormat[Client]                                 = jsonFormat7(Client)
 
-  implicit val purposeFormat: RootJsonFormat[Purpose]                                 = jsonFormat18(Purpose)
+  implicit val purposeFormat: RootJsonFormat[Purpose]                                 = jsonFormat17(Purpose)
   implicit val purposesFormat: RootJsonFormat[Purposes]                               = jsonFormat2(Purposes)
   implicit val purposeAdditionDetailsSeed: RootJsonFormat[PurposeAdditionDetailsSeed] = jsonFormat1(
     PurposeAdditionDetailsSeed

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/types/CatalogProcessServiceTypes.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/types/CatalogProcessServiceTypes.scala
@@ -55,7 +55,7 @@ object CatalogProcessServiceTypes {
     )
   }
 
-  implicit class RiskAnalysisFormConverter(private val ra: RiskAnalysisForm) extends AnyVal {
+  implicit class RiskAnalysisFormSeedConverter(private val ra: RiskAnalysisFormSeed) extends AnyVal {
     def toProcess: CatalogProcess.EServiceRiskAnalysisFormSeed =
       CatalogProcess.EServiceRiskAnalysisFormSeed(version = ra.version, answers = ra.answers)
   }

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/types/PurposeProcessServiceTypes.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/types/PurposeProcessServiceTypes.scala
@@ -41,12 +41,13 @@ object PurposeProcessServiceTypes {
   }
 
   implicit class ProcessRiskAnalysisFormConverter(private val raf: PurposeProcess.RiskAnalysisForm) extends AnyVal {
-    def toApi: RiskAnalysisForm = RiskAnalysisForm(version = raf.version, answers = raf.answers)
+    def toApi: RiskAnalysisForm =
+      RiskAnalysisForm(version = raf.version, answers = raf.answers, riskAnalysisId = raf.riskAnalysisId)
   }
 
-  implicit class RiskAnalysisFormConverter(private val raf: RiskAnalysisForm) extends AnyVal {
-    def toProcess: PurposeProcess.RiskAnalysisForm =
-      PurposeProcess.RiskAnalysisForm(version = raf.version, answers = raf.answers)
+  implicit class RiskAnalysisFormSeedConverter(private val raf: RiskAnalysisFormSeed) extends AnyVal {
+    def toProcess: PurposeProcess.RiskAnalysisFormSeed =
+      PurposeProcess.RiskAnalysisFormSeed(version = raf.version, answers = raf.answers)
   }
 
   implicit class PurposeVersionUpdateSeedConverter(private val seed: WaitingForApprovalPurposeVersionUpdateContentSeed)
@@ -134,14 +135,7 @@ object PurposeProcessServiceTypes {
       isFreeOfCharge = p.isFreeOfCharge,
       freeOfChargeReason = p.freeOfChargeReason,
       dailyCallsPerConsumer = currentDescriptor.dailyCallsPerConsumer,
-      dailyCallsTotal = currentDescriptor.dailyCallsTotal,
-      riskAnalysisId = if (eService.mode == CatalogProcess.EServiceMode.RECEIVE) {
-        p.riskAnalysisForm
-          .flatMap(form => form.riskAnalysisId)
-          .toList
-          .intersect(eService.riskAnalysis.map(_.id))
-          .headOption
-      } else None
+      dailyCallsTotal = currentDescriptor.dailyCallsTotal
     )
 
     def toApiResource: CreatedResource = CreatedResource(id = p.id)


### PR DESCRIPTION
Requires https://github.com/pagopa/interop-be-purpose-process/pull/187

⚠️ The API spec is changed:
- the field `riskAnalysisId` has been moved from `Purpose` to `RiskAnalysisForm`
- `RiskAnalysisFormSeed` is now used to create the risk analysis form