### PR TITLE
PIN-4551 Added explode parameter to false

### DIFF
--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -7359,6 +7359,7 @@ paths:
             type: array
             items:
               $ref: '#/components/schemas/AttributeKind'
+            default: []   
           required: true
           explode: false
       responses:

--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -7360,6 +7360,7 @@ paths:
             items:
               $ref: '#/components/schemas/AttributeKind'
           required: true
+          explode: false
       responses:
         '200':
           description: A List of Attributes


### PR DESCRIPTION
Missing also on '/clients/{clientId}/keys' path
Weird behaviour because explode: false is the default