### PR TITLE
PIN-4915: hotfix for exportEservice

### DIFF
--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
@@ -950,6 +950,9 @@ final case class EServicesApiServiceImpl(
       zipOut.write(config.toString.getBytes("UTF-8"))
       zipOut.closeEntry()
 
+      zipOut.finish()
+      zipOut.flush()
+      bos.flush()
       zipOut.close()
       bos.toByteArray
     }
@@ -975,24 +978,24 @@ final case class EServicesApiServiceImpl(
       )
       config     = extractConfig(eService, descriptor)
       folderName = s"${eService.id}_${descriptor.id}"
-      zipName    = s"$organizationId/$folderName.zip"
+      zipPath    = s"$organizationId/$folderName.zip"
       zipFile    = createZip(folderName, docFiles, (interfaceFile, interface.name), config)
       _          = fileManager.storeBytes(
         ApplicationConfiguration.exportEserviceContainer,
         ApplicationConfiguration.exportEservicePath,
-        zipName
+        zipPath
       )(zipFile)
       presignedUrl <- fileManager
         .generateGetPresignedUrl(
           ApplicationConfiguration.exportEserviceContainer,
           ApplicationConfiguration.exportEservicePath,
-          zipName,
+          zipPath,
           FiniteDuration(ApplicationConfiguration.getUrlDurationMinutes, TimeUnit.MINUTES)
         )
         .toEither
         .toFuture
       presignedURI <- Try(new URI(presignedUrl)).toEither.toFuture
-    } yield FileResource(zipName, presignedURI)
+    } yield FileResource(s"$folderName.zip", presignedURI)
 
     onComplete(result) {
       val headers: List[HttpHeader] = headersFromContext()


### PR DESCRIPTION
The endpoint exports a file named like `69e2865e-65ab-4e48-a638-2037a9ee2ee7/ce25dbb7-8866-4b55-829c-492976bf579e_dd80f4c3-6f38-41c0-85a6-0d6288cca62e.zip` which is incorrect and the zip itself isn't a proper zip as the `End-of-central-directory signature` is not found when trying to unzip it.

This PR should fix both issues.