### PR TITLE
PIN-4915: hotfix for importEservice

### DIFF
--- a/src/main/resources/interface-specification.yml
+++ b/src/main/resources/interface-specification.yml
@@ -3960,7 +3960,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreatedResource'
+                $ref: '#/components/schemas/CreatedEServiceDescriptor'
         '403':
           description: Forbidden
           content:

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
@@ -31,6 +31,7 @@ import it.pagopa.interop.backendforfrontend.service.types.CatalogProcessServiceT
 import it.pagopa.interop.backendforfrontend.service.types.TenantProcessServiceTypes._
 import it.pagopa.interop.catalogprocess.client.{model => CatalogProcess}
 import it.pagopa.interop.commons.files.service.FileManager
+import it.pagopa.interop.commons.jwt.{ADMIN_ROLE, API_ROLE, authorize}
 import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
 import it.pagopa.interop.commons.utils.AkkaUtils._
 import it.pagopa.interop.commons.utils.OpenapiUtils.parseArrayParameters
@@ -869,7 +870,7 @@ final case class EServicesApiServiceImpl(
     contexts: Seq[(String, String)],
     toEntityMarshallerFileResource: ToEntityMarshaller[FileResource],
     toEntityMarshallerProblem: ToEntityMarshaller[Problem]
-  ): Route = {
+  ): Route = authorize(ADMIN_ROLE, API_ROLE) {
 
     def extractConfig(eService: CatalogProcess.EService, descriptor: CatalogProcess.EServiceDescriptor): Json = {
       JsonObject(
@@ -1036,7 +1037,7 @@ final case class EServicesApiServiceImpl(
   override def importEService(fileResource: FileResource)(implicit
     contexts: Seq[(String, String)],
     toEntityMarshallerProblem: ToEntityMarshaller[Problem],
-    toEntityMarshallerCreatedResource: ToEntityMarshaller[CreatedResource]
+    toEntityMarshallerCreatedResource: ToEntityMarshaller[CreatedEServiceDescriptor]
   ): Route = {
 
     def extractZipToTempDirectory(zipBytes: Array[Byte], tenantId: String): Either[Throwable, Path] = {
@@ -1161,7 +1162,7 @@ final case class EServicesApiServiceImpl(
       }
     }
 
-    val result: Future[CreatedResource] = for {
+    val result: Future[CreatedEServiceDescriptor] = for {
       tenantId         <- getOrganizationIdFuture(contexts)
       zipFile          <- fileManager.getFile(ApplicationConfiguration.importEServiceContainer)(
         s"${ApplicationConfiguration.importEServicePath}/$tenantId/${fileResource.filename}"
@@ -1202,7 +1203,7 @@ final case class EServicesApiServiceImpl(
       _          <- importedEservice.descriptor.docs
         .traverse(verifyAndCreateImportedDoc(eService, descriptor, zipPath, _, "DOCUMENT"))
       _ = deleteTempDirectory(zipPath)
-    } yield CreatedResource(eService.id)
+    } yield CreatedEServiceDescriptor(id = eService.id, descriptorId = descriptor.id)
 
     onComplete(result) {
       val headers: List[HttpHeader] = headersFromContext()

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
@@ -31,7 +31,6 @@ import it.pagopa.interop.backendforfrontend.service.types.CatalogProcessServiceT
 import it.pagopa.interop.backendforfrontend.service.types.TenantProcessServiceTypes._
 import it.pagopa.interop.catalogprocess.client.{model => CatalogProcess}
 import it.pagopa.interop.commons.files.service.FileManager
-import it.pagopa.interop.commons.jwt.{ADMIN_ROLE, API_ROLE, authorize}
 import it.pagopa.interop.commons.logging.{CanLogContextFields, ContextFieldsToLog}
 import it.pagopa.interop.commons.utils.AkkaUtils._
 import it.pagopa.interop.commons.utils.OpenapiUtils.parseArrayParameters
@@ -870,7 +869,7 @@ final case class EServicesApiServiceImpl(
     contexts: Seq[(String, String)],
     toEntityMarshallerFileResource: ToEntityMarshaller[FileResource],
     toEntityMarshallerProblem: ToEntityMarshaller[Problem]
-  ): Route = authorize(ADMIN_ROLE, API_ROLE) {
+  ): Route = {
 
     def extractConfig(eService: CatalogProcess.EService, descriptor: CatalogProcess.EServiceDescriptor): Json = {
       JsonObject(


### PR DESCRIPTION
`ImportEservice` returned only `eServiceId` while the frontend requires `descriptorId` too.

This PR change its return type to the correct one