### PR TITLE
PIN-4916: Fix accessing correct path on import

### DIFF
--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
@@ -1062,7 +1062,7 @@ final case class EServicesApiServiceImpl(
               }
             }
         }
-        tempDir.resolve(fileResource.filename)
+        tempDir.resolve(fileResource.filename.stripSuffix(".zip"))
       }.toEither
     }
 


### PR DESCRIPTION
Since we assume that the user will insert as fileName the name of zip including the extension we have to strip it