### PR TITLE
PIN-4916: importEservice hotfix

### DIFF
--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
@@ -1062,7 +1062,7 @@ final case class EServicesApiServiceImpl(
               }
             }
         }
-        tempDir.resolve(fileResource.filename.stripSuffix(".zip"))
+        tempDir
       }.toEither
     }
 
@@ -1167,7 +1167,8 @@ final case class EServicesApiServiceImpl(
         s"${ApplicationConfiguration.importEServicePath}/$tenantId/${fileResource.filename}"
       )
       zipPath          <- extractZipToTempDirectory(zipFile, tenantId).toFuture
-      importedEservice <- checkZipStructure(zipPath).toFuture.recoverWith { case ex: Throwable =>
+      folderPath       = zipPath.resolve(fileResource.filename.stripSuffix(".zip"))
+      importedEservice <- checkZipStructure(folderPath).toFuture.recoverWith { case ex: Throwable =>
         deleteTempDirectory(zipPath)
         Future.failed(ex)
       }
@@ -1196,11 +1197,11 @@ final case class EServicesApiServiceImpl(
       }
       _          <- importedEservice.descriptor.interface match {
         case Some(interface) =>
-          verifyAndCreateImportedDoc(eService, descriptor, zipPath, interface, "INTERFACE")
+          verifyAndCreateImportedDoc(eService, descriptor, folderPath, interface, "INTERFACE")
         case None            => Future.unit
       }
       _          <- importedEservice.descriptor.docs
-        .traverse(verifyAndCreateImportedDoc(eService, descriptor, zipPath, _, "DOCUMENT"))
+        .traverse(verifyAndCreateImportedDoc(eService, descriptor, folderPath, _, "DOCUMENT"))
       _ = deleteTempDirectory(zipPath)
     } yield CreatedEServiceDescriptor(id = eService.id, descriptorId = descriptor.id)
 


### PR DESCRIPTION
Created a new `folderPath` which is used when accessing the content of the zip file, meanwhile the `zipPath` is the parent of that folder.

Example: 

Given `/tmp/69e2865e-65ab-4e48-a638-2037a9ee2ee7_extractedZip17153365832312299331/ce25dbb7-8866-4b55-829c-492976bf579e_dd80f4c3-6f38-41c0-85a6-0d6288cca62e`

zipPath: `/tmp/69e2865e-65ab-4e48-a638-2037a9ee2ee7_extractedZip17153365832312299331`
folderPath: `/tmp/69e2865e-65ab-4e48-a638-2037a9ee2ee7_extractedZip17153365832312299331/ce25dbb7-8866-4b55-829c-492976bf579e_dd80f4c3-6f38-41c0-85a6-0d6288cca62e`