### PR TITLE
PIN-4916: Import and export hotfixes

### DIFF
--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
@@ -1178,6 +1178,9 @@ final case class EServicesApiServiceImpl(
       zipFile  <- fileManager.getFile(ApplicationConfiguration.importEServiceContainer)(
         s"${ApplicationConfiguration.importEServicePath}/$tenantId/${fileResource.filename}"
       )
+      _        <- fileManager.delete(ApplicationConfiguration.importEServiceContainer)(
+        s"${ApplicationConfiguration.importEServicePath}/$tenantId/${fileResource.filename}"
+      )
       zipPath  <- extractZipToTempDirectory(zipFile, tenantId).toFuture
       folderPath = zipPath.resolve(fileResource.filename.stripSuffix(".zip"))
       importedEservice <- checkZipStructure(folderPath).toFuture.recoverWith { case ex: Throwable =>

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
@@ -1083,15 +1083,6 @@ final case class EServicesApiServiceImpl(
         importedEservice <- Either
           .catchNonFatal(jsonContent.parseJson.convertTo[ImportedEservice])
           .leftMap(ex => InvalidZipStructure(directoryName, "Error decoding configuration.json: " + ex.toString))
-        _                <- {
-          importedEservice.mode match {
-            case EServiceMode.DELIVER if importedEservice.riskAnalysis.nonEmpty =>
-              Left(InvalidZipStructure(directoryName, "riskAnalysis is not allowed in DELIVER mode"))
-            case EServiceMode.RECEIVE if importedEservice.riskAnalysis.isEmpty  =>
-              Left(InvalidZipStructure(directoryName, "riskAnalysis is required in RECEIVE mode"))
-            case _                                                              => Right(())
-          }
-        }
         _ <- importedEservice.descriptor.docs.foldLeft[Either[InvalidZipStructure, Unit]](Right(())) { (acc, doc) =>
           acc.flatMap(_ => fileExists(path.resolve(doc.path)))
         }

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
@@ -886,7 +886,7 @@ final case class EServicesApiServiceImpl(
           "docs"                    -> Json.arr(
             descriptor.docs.map(doc =>
               Json
-                .obj("prettyName" -> Json.fromString(doc.prettyName), "path" -> Json.fromString(s"documents/$doc.name"))
+                .obj("prettyName" -> Json.fromString(doc.prettyName), "path" -> Json.fromString(s"documents/${doc.name}"))
             ): _* // `: _*` is used to convert Seq to varargs for Json.arr
           ),
           "audience"                -> Json.arr(descriptor.audience.map(Json.fromString): _*),

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
@@ -875,14 +875,14 @@ final case class EServicesApiServiceImpl(
       JsonObject(
         "name"         -> Json.fromString(eService.name),
         "description"  -> Json.fromString(eService.description),
-        "technology"   -> Json.fromString(eService.technology.toString),
-        "mode"         -> Json.fromString(eService.mode.toString),
+        "technology"   -> Json.fromString(eService.technology.toApi.toString),
+        "mode"         -> Json.fromString(eService.mode.toApi.toString),
         "descriptor"   -> Json.obj(
           "interface"               -> descriptor.interface
             .map(interface =>
               Json.obj("prettyName" -> Json.fromString(interface.prettyName), "path" -> Json.fromString(interface.name))
             )
-            .getOrElse(Json.obj()),
+            .getOrElse(Json.Null),
           "docs"                    -> Json.arr(
             descriptor.docs.map(doc =>
               Json
@@ -893,25 +893,28 @@ final case class EServicesApiServiceImpl(
           "voucherLifespan"         -> Json.fromInt(descriptor.voucherLifespan),
           "dailyCallsPerConsumer"   -> Json.fromInt(descriptor.dailyCallsPerConsumer),
           "dailyCallsTotal"         -> Json.fromInt(descriptor.dailyCallsTotal),
-          "description"             -> descriptor.description.map(Json.fromString).getOrElse(Json.obj()),
-          "agreementApprovalPolicy" -> Json.fromString(descriptor.agreementApprovalPolicy.toString)
+          "description"             -> descriptor.description.map(Json.fromString).getOrElse(Json.Null),
+          "agreementApprovalPolicy" -> Json.fromString(descriptor.agreementApprovalPolicy.toApi.toString)
         ),
         "riskAnalysis" -> Json.arr(
           eService.riskAnalysis.map(ra =>
             Json.obj(
-              "version"       -> Json.fromString(ra.riskAnalysisForm.version),
-              "singleAnswers" -> Json.arr(
-                ra.riskAnalysisForm.singleAnswers.map(sa =>
-                  Json.obj(
-                    "key"   -> Json.fromString(sa.key),
-                    "value" -> sa.value.map(Json.fromString).getOrElse(Json.obj())
-                  )
-                ): _*
-              ),
-              "multiAnswers"  -> Json.arr(
-                ra.riskAnalysisForm.multiAnswers.map(ma =>
-                  Json.obj("key" -> Json.fromString(ma.key), "values" -> Json.arr(ma.values.map(Json.fromString): _*))
-                ): _*
+              "name"             -> Json.fromString(ra.name),
+              "riskAnalysisForm" -> Json.obj(
+                "version"       -> Json.fromString(ra.riskAnalysisForm.version),
+                "singleAnswers" -> Json.arr(
+                  ra.riskAnalysisForm.singleAnswers.map(sa =>
+                    Json.obj(
+                      "key"   -> Json.fromString(sa.key),
+                      "value" -> sa.value.map(Json.fromString).getOrElse(Json.Null)
+                    )
+                  ): _*
+                ),
+                "multiAnswers"  -> Json.arr(
+                  ra.riskAnalysisForm.multiAnswers.map(ma =>
+                    Json.obj("key" -> Json.fromString(ma.key), "values" -> Json.arr(ma.values.map(Json.fromString): _*))
+                  ): _*
+                )
               )
             )
           ): _*
@@ -1079,8 +1082,16 @@ final case class EServicesApiServiceImpl(
           .leftMap(ex => InvalidZipStructure(directoryName, "Error reading configuration.json: " + ex.toString))
         importedEservice <- Either
           .catchNonFatal(jsonContent.parseJson.convertTo[ImportedEservice])
-          .leftMap(ex => InvalidZipStructure(directoryName, "Error decoding configuration.json: " + ex.toString)
-        )
+          .leftMap(ex => InvalidZipStructure(directoryName, "Error decoding configuration.json: " + ex.toString))
+        _                <- {
+          importedEservice.mode match {
+            case EServiceMode.DELIVER if importedEservice.riskAnalysis.nonEmpty =>
+              Left(InvalidZipStructure(directoryName, "riskAnalysis is not allowed in DELIVER mode"))
+            case EServiceMode.RECEIVE if importedEservice.riskAnalysis.isEmpty  =>
+              Left(InvalidZipStructure(directoryName, "riskAnalysis is required in RECEIVE mode"))
+            case _                                                              => Right(())
+          }
+        }
         _ <- importedEservice.descriptor.docs.foldLeft[Either[InvalidZipStructure, Unit]](Right(())) { (acc, doc) =>
           acc.flatMap(_ => fileExists(path.resolve(doc.path)))
         }
@@ -1163,12 +1174,12 @@ final case class EServicesApiServiceImpl(
     }
 
     val result: Future[CreatedEServiceDescriptor] = for {
-      tenantId         <- getOrganizationIdFuture(contexts)
-      zipFile          <- fileManager.getFile(ApplicationConfiguration.importEServiceContainer)(
+      tenantId <- getOrganizationIdFuture(contexts)
+      zipFile  <- fileManager.getFile(ApplicationConfiguration.importEServiceContainer)(
         s"${ApplicationConfiguration.importEServicePath}/$tenantId/${fileResource.filename}"
       )
-      zipPath          <- extractZipToTempDirectory(zipFile, tenantId).toFuture
-      folderPath       = zipPath.resolve(fileResource.filename.stripSuffix(".zip"))
+      zipPath  <- extractZipToTempDirectory(zipFile, tenantId).toFuture
+      folderPath = zipPath.resolve(fileResource.filename.stripSuffix(".zip"))
       importedEservice <- checkZipStructure(folderPath).toFuture.recoverWith { case ex: Throwable =>
         deleteTempDirectory(zipPath)
         Future.failed(ex)
@@ -1179,9 +1190,20 @@ final case class EServicesApiServiceImpl(
         technology = importedEservice.technology.toProcess,
         mode = importedEservice.mode.toProcess
       )
-      eService <- catalogProcessService.createEService(eserviceSeed).recoverWith { case ex: Throwable =>
+      eService   <- catalogProcessService.createEService(eserviceSeed).recoverWith { case ex: Throwable =>
         deleteTempDirectory(zipPath)
         Future.failed(ex)
+      }
+      _          <- Future.traverse(importedEservice.riskAnalysis) { ra =>
+        catalogProcessService
+          .createRiskAnalysis(
+            eServiceId = eService.id,
+            CatalogProcess.EServiceRiskAnalysisSeed(name = ra.name, riskAnalysisForm = ra.riskAnalysisForm.toProcess)
+          )
+          .recoverWith { case ex: Throwable =>
+            deleteTempDirectory(zipPath)
+            catalogProcessService.deleteEService(eService.id).flatMap(_ => Future.failed(ex))
+          }
       }
       descriptorSeed = CatalogProcess.EServiceDescriptorSeed(
         audience = importedEservice.descriptor.audience,

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/package.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/package.scala
@@ -20,6 +20,7 @@ import it.pagopa.interop.backendforfrontend.service.model.{
   ImportedEservice,
   ImportedMultiAnswer,
   ImportedRiskAnalysis,
+  ImportedRiskAnalysisForm,
   ImportedSingleAnswer
 }
 
@@ -63,7 +64,10 @@ package object impl extends SprayJsonSupport with DefaultJsonProtocol {
   implicit val importedDescriptorFormat: RootJsonFormat[ImportedDescriptor]     = jsonFormat8(ImportedDescriptor)
   implicit val importedSingleAnswerFormat: RootJsonFormat[ImportedSingleAnswer] = jsonFormat2(ImportedSingleAnswer)
   implicit val importedMultiAnswerFormat: RootJsonFormat[ImportedMultiAnswer]   = jsonFormat2(ImportedMultiAnswer)
-  implicit val importedRiskAnalysisFormat: RootJsonFormat[ImportedRiskAnalysis] = jsonFormat3(ImportedRiskAnalysis)
+  implicit val importedRiskAnalysisFormFormat: RootJsonFormat[ImportedRiskAnalysisForm] = jsonFormat3(
+    ImportedRiskAnalysisForm
+  )
+  implicit val importedRiskAnalysisFormat: RootJsonFormat[ImportedRiskAnalysis] = jsonFormat2(ImportedRiskAnalysis)
   implicit val importedEserviceFormat: RootJsonFormat[ImportedEservice]         = jsonFormat6(ImportedEservice)
 
   implicit val declaredTenantAttributeSeedFormat: RootJsonFormat[DeclaredTenantAttributeSeed] =

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/model/ImportedEservice.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/model/ImportedEservice.scala
@@ -15,11 +15,12 @@ final case class ImportedDescriptor(
 )
 final case class ImportedSingleAnswer(key: String, value: Option[String])
 final case class ImportedMultiAnswer(key: String, values: Seq[String])
-final case class ImportedRiskAnalysis(
+final case class ImportedRiskAnalysisForm(
   version: String,
   singleAnswers: Seq[ImportedSingleAnswer],
   multiAnswers: Seq[ImportedMultiAnswer]
 )
+final case class ImportedRiskAnalysis(name: String, riskAnalysisForm: ImportedRiskAnalysisForm)
 
 final case class ImportedEservice(
   name: String,
@@ -27,5 +28,5 @@ final case class ImportedEservice(
   technology: EServiceTechnology,
   mode: EServiceMode,
   descriptor: ImportedDescriptor,
-  riskAnalysis: Option[ImportedRiskAnalysis]
+  riskAnalysis: Seq[ImportedRiskAnalysis]
 )

--- a/src/main/scala/it/pagopa/interop/backendforfrontend/service/types/CatalogProcessServiceTypes.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/service/types/CatalogProcessServiceTypes.scala
@@ -4,6 +4,7 @@ import cats.syntax.all._
 import it.pagopa.interop.attributeregistryprocess.client.{model => AttributeProcess}
 import it.pagopa.interop.backendforfrontend.error.BFFErrors.AttributeNotExists
 import it.pagopa.interop.backendforfrontend.model._
+import it.pagopa.interop.backendforfrontend.service.model.{ImportedRiskAnalysis, ImportedRiskAnalysisForm}
 import it.pagopa.interop.catalogmanagement.{model => CatalogManagement}
 import it.pagopa.interop.commons.utils.TypeConversions.EitherOps
 import it.pagopa.interop.catalogprocess.client.{model => CatalogProcess}
@@ -58,6 +59,15 @@ object CatalogProcessServiceTypes {
   implicit class RiskAnalysisFormSeedConverter(private val ra: RiskAnalysisFormSeed) extends AnyVal {
     def toProcess: CatalogProcess.EServiceRiskAnalysisFormSeed =
       CatalogProcess.EServiceRiskAnalysisFormSeed(version = ra.version, answers = ra.answers)
+  }
+
+  implicit class ImportedRiskAnalysisFormSeedConverter(private val ira: ImportedRiskAnalysisForm) extends AnyVal {
+    def toProcess: CatalogProcess.EServiceRiskAnalysisFormSeed =
+      CatalogProcess.EServiceRiskAnalysisFormSeed(
+        version = ira.version,
+        answers =
+          (ira.singleAnswers.map(a => a.key -> a.value.toSeq) ++ ira.multiAnswers.map(a => a.key -> a.values)).toMap
+      )
   }
 
   implicit class EServiceTechnologyConverter(private val est: EServiceTechnology) extends AnyVal {
@@ -267,6 +277,11 @@ object CatalogProcessServiceTypes {
   implicit class EServiceRiskAnalysisSeedConverter(private val eras: EServiceRiskAnalysisSeed) extends AnyVal {
     def toProcess: CatalogProcess.EServiceRiskAnalysisSeed =
       CatalogProcess.EServiceRiskAnalysisSeed(name = eras.name, riskAnalysisForm = eras.riskAnalysisForm.toProcess)
+  }
+
+  implicit class ImportedEserviceRiskAnalysisConverter(private val ieras: ImportedRiskAnalysis) extends AnyVal {
+    def toProcess: CatalogProcess.EServiceRiskAnalysisSeed =
+      CatalogProcess.EServiceRiskAnalysisSeed(name = ieras.name, riskAnalysisForm = ieras.riskAnalysisForm.toProcess)
   }
 
   implicit class DocumentKindWrapper(private val str: String) extends AnyVal {


### PR DESCRIPTION
Added missed riskAnalysis creation and fixed exported types in using some BFF types instead of the process ones.

`Technology`, `AgreementApprovalPolicy` and `mode` are converted to the BFF type in order to reuse the already available formats for json decoding

Added creation of riskAnalysis and delete of exported eservice file