### PR TITLE
PIN-4916: removed deletion of exported zip

### DIFF
--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
@@ -1169,9 +1169,6 @@ final case class EServicesApiServiceImpl(
       zipFile  <- fileManager.getFile(ApplicationConfiguration.importEServiceContainer)(
         s"${ApplicationConfiguration.importEServicePath}/$tenantId/${fileResource.filename}"
       )
-      _        <- fileManager.delete(ApplicationConfiguration.importEServiceContainer)(
-        s"${ApplicationConfiguration.importEServicePath}/$tenantId/${fileResource.filename}"
-      )
       zipPath  <- extractZipToTempDirectory(zipFile, tenantId).toFuture
       folderPath = zipPath.resolve(fileResource.filename.stripSuffix(".zip"))
       importedEservice <- checkZipStructure(folderPath).toFuture.recoverWith { case ex: Throwable =>


### PR DESCRIPTION
Since the BFF is not allowed to delete on AWS and the presignedUrl already has a retention policy, I removed the deletion of the exported eservice zip.