### PR TITLE
PIN-4916: fix file detection

### DIFF
--- a/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
+++ b/src/main/scala/it/pagopa/interop/backendforfrontend/api/impl/EServicesApiServiceImpl.scala
@@ -1091,10 +1091,10 @@ final case class EServicesApiServiceImpl(
           case None                 => Right(())
         }
         _ <- {
-          val filePaths    = Files.list(path).iterator().asScala.map(_.toString).toSet
-          val allowedFiles = Set("configuration.json") ++
-            importedEservice.descriptor.docs.map(_.path) ++
-            importedEservice.descriptor.interface.map(_.path)
+          val filePaths    = Files.list(path).iterator().asScala.map(_.getFileName.toString).toSet
+          val allowedFiles = Set("configuration.json", "documents") ++
+            importedEservice.descriptor.docs.map(_.path.split("/").last) ++
+            importedEservice.descriptor.interface.map(_.path.split("/").last)
 
           val extraFiles = filePaths -- allowedFiles
           Either.cond(


### PR DESCRIPTION
Fix needed in order to detect the allowed files.

Example of the current error:
`Extra files found: /tmp/69e2865e-65ab-4e48-a638-2037a9ee2ee7_extractedZip17658200130824202533/493958e6-3da0-4543-927f-4d41577a49c1_66433bac-d3a6-43de-8a34-8071ea024c21/interface.yaml, /tmp/69e2865e-65ab-4e48-a638-2037a9ee2ee7_extractedZip17658200130824202533/493958e6-3da0-4543-927f-4d41577a49c1_66433bac-d3a6-43de-8a34-8071ea024c21/documents, /tmp/69e2865e-65ab-4e48-a638-2037a9ee2ee7_extractedZip17658200130824202533/493958e6-3da0-4543-927f-4d41577a49c1_66433bac-d3a6-43de-8a34-8071ea024c21/configuration.json"`